### PR TITLE
fix format of string for promptsource dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "numpy==1.23.5",
     "pandas==1.5.1",
     "transformers==4.25.1",
-    "git+https://github.com/bigscience-workshop/promptsource.git",
+    "promptsource @ git+https://github.com/bigscience-workshop/promptsource.git",
     "torch",
     "sentencepiece==0.1.97",
     "protobuf==3.20.*",


### PR DESCRIPTION
Fixes the following error:

```
pip install -e .[dev]

Obtaining file:///home/wombat_share/laurito/elk
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [48 lines of output]
      /tmp/pip-build-env-ojgr903q/overlay/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py:108: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
        warnings.warn(msg, _BetaConfiguration)
      configuration error: `project.dependencies[{data__dependencies_x}]` must be pep508
      DESCRIPTION:
          Project dependency specification according to PEP 508
      
      GIVEN VALUE:
          "git+https://github.com/bigscience-workshop/promptsource.git"
      
      OFFENDING RULE: 'format'
      
      DEFINITION:
          {
              "$id": "#/definitions/dependency",
              "title": "Dependency",
              "type": "string",
              "format": "pep508"
          }
      Traceback (most recent call last):
        File "/home/wombat_share/laurito/elk/.venv/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
          main()
        File "/home/wombat_share/laurito/elk/.venv/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/home/wombat_share/laurito/elk/.venv/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 144, in get_requires_for_build_editable
          return hook(config_settings)
        File "/tmp/pip-build-env-ojgr903q/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 447, in get_requires_for_build_editable
          return self.get_requires_for_build_wheel(config_settings)
        File "/tmp/pip-build-env-ojgr903q/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 338, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "/tmp/pip-build-env-ojgr903q/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 320, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-ojgr903q/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 335, in run_setup
          exec(code, locals())
        File "<string>", line 1, in <module>
        File "/tmp/pip-build-env-ojgr903q/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 108, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-ojgr903q/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 159, in setup
          dist.parse_config_files()
        File "/tmp/pip-build-env-ojgr903q/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 872, in parse_config_files
          pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
        File "/tmp/pip-build-env-ojgr903q/overlay/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 62, in apply_configuration
          config = read_configuration(filepath, True, ignore_option_errors, dist)
        File "/tmp/pip-build-env-ojgr903q/overlay/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 126, in read_configuration
          validate(subset, filepath)
        File "/tmp/pip-build-env-ojgr903q/overlay/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 51, in validate
          raise ValueError(f"{error}\n{summary}") from None
      ValueError: invalid pyproject.toml config: `project.dependencies[{data__dependencies_x}]`.
      configuration error: `project.dependencies[{data__dependencies_x}]` must be pep508
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build editable did not run successfully.
│ exit code: 1
╰─> See above for output.
```