### PR TITLE
fixed max_example_bug

### DIFF
--- a/elk/extraction/prompt_collator.py
+++ b/elk/extraction/prompt_collator.py
@@ -70,6 +70,9 @@ class PromptCollator(Dataset):
 
         self.dataset = self.dataset.shuffle(seed=seed)
         if max_examples:
+            num_examples = len(self.dataset)
+            if max_examples > num_examples:
+                max_examples = num_examples
             self.dataset = self.dataset.select(range(max_examples))
 
         self.label_column = label_column


### PR DESCRIPTION
If the max_examples parameter is larger than the number of examples in the dataset, you will get an error when trying to select a range that is out of bounds. To fix this, you can check the number of examples in the dataset and adjust the max_examples parameter accordingly.