### PR TITLE
Added error message for prompt-based loss and num_variants=1

### DIFF
--- a/elk/training/losses.py
+++ b/elk/training/losses.py
@@ -146,7 +146,7 @@ def prompt_var_loss(logit0: Tensor, logit1: Tensor, coef: float = 1.0) -> Tensor
     assert len(logit0.shape) in [1, 2]
     if logit0.shape[-1] == 1:
         warnings.warn(
-            "Only one variant provided. Prompt variance loss will equal CCS loss."
+            "Only one variant provided. Prompt variance loss will cause errors."
         )
     p0, p1 = logit0.sigmoid(), logit1.sigmoid()
     prompt_variance = p0.var(dim=-1).mean() + p1.var(dim=-1).mean()

--- a/elk/training/reporter.py
+++ b/elk/training/reporter.py
@@ -59,7 +59,7 @@ class ReporterConfig(Serializable):
     bias: bool = True
     hidden_size: Optional[int] = None
     init: Literal["default", "pca", "spherical", "zero"] = "default"
-    loss: list[str] = field(default_factory=lambda: ["ccs_prompt_var"])
+    loss: list[str] = field(default_factory=lambda: ["ccs"])
     loss_dict: dict[str, float] = field(default_factory=dict, init=False)
     num_layers: int = 1
     pre_ln: bool = False

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -148,6 +148,17 @@ def train_reporter(
 
 def train(cfg: RunConfig, out_dir: Optional[Path] = None):
     # Extract the hidden states first if necessary
+    print("losses: ", cfg.net.loss_dict.keys())
+    is_prompt_based_loss = (
+        "ccs_prompt_var" in cfg.net.loss_dict.keys()
+        or "prompt_var_squared" in cfg.net.loss_dict.keys()
+    )
+    if cfg.data.prompts.num_variants == 1 and is_prompt_based_loss:
+        raise ValueError(
+            "Loss functions ccs_prompt_var and prompt_var_squared "
+            "incompatible with --num_variants 1."
+        )
+
     ds = extract(cfg.data, max_gpus=cfg.max_gpus)
 
     if out_dir is None:

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -148,7 +148,6 @@ def train_reporter(
 
 def train(cfg: RunConfig, out_dir: Optional[Path] = None):
     # Extract the hidden states first if necessary
-    print("losses: ", cfg.net.loss_dict.keys())
     is_prompt_based_loss = (
         "ccs_prompt_var" in cfg.net.loss_dict.keys()
         or "prompt_var_squared" in cfg.net.loss_dict.keys()


### PR DESCRIPTION
The loss functions ccs_prompt_var and prompt_var_squared cause NaN errors when --num_variants is set to 1, because of the variance calculation.

I added an error message in train.py for this.

As ccs_prompt_var and num_variants=1 are set by default, this means an error is thrown by default, which is not ideal.