### PR TITLE
Remove marker for cpu test, add marker for future gpu tests

### DIFF
--- a/.github/workflows/cpu_ci.yml
+++ b/.github/workflows/cpu_ci.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Type Checking
         uses: jakebailey/pyright-action@v1
 
-      - name: Run CPU Tests
-        run: pytest -m cpu
+      - name: Run normal tests, excluding GPU tests
+        run: pytest -m "not gpu"
 
   run-tests-python3_10:
     runs-on: ubuntu-latest
@@ -42,5 +42,5 @@ jobs:
       - name: Type Checking
         uses: jakebailey/pyright-action@v1
 
-      - name: Run CPU Tests
-        run: pytest -m cpu
+      - name: Run normal tests, excluding GPU tests
+        run: pytest -m "not gpu"

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -7,7 +7,6 @@ from sklearn.linear_model import LogisticRegression
 from elk.training.classifier import Classifier
 
 
-@pytest.mark.cpu
 def test_classifier_roughly_same_sklearn():
     input_dims: int = 10
     # make a classification problem of 1000 samples with input_dims features

--- a/tests/test_gpu_example.py
+++ b/tests/test_gpu_example.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.mark.gpu
+def test_gpu_example():
+    """Will only run if the `gpu` mark is specified
+    This is just an example test to show how to use the `gpu` mark
+    We'll need to implement a GPU runner in the CI for actual GPU tests
+    GPU tests can be run with `pytest -m gpu`"""
+    assert True

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -12,7 +12,6 @@ import pytest
     # ...and the total sum of the floats
     st.integers(min_value=1, max_value=int(np.finfo(np.float32).max)),
 )
-@pytest.mark.cpu
 def test_stochastic_rounding(num_parts: int, total: int):
     # Randomly sample the breakdown of the total into floats
     rng = np.random.default_rng(42)


### PR DESCRIPTION
This PR removes the pytest.mark.cpu decorators, so all tests are automatically added to the CI. 

For future tests that require the GPU, they can be marked with `pytest.mark.gpu` instead. These tests won't run on the cpu CI