### PR TITLE
Replace held_out_split with select_train_val_splits

### DIFF
--- a/elk/evaluation/evaluate.py
+++ b/elk/evaluation/evaluate.py
@@ -19,7 +19,12 @@ from elk.training.preprocessing import normalize
 
 from ..extraction import ExtractionConfig, extract
 from ..files import elk_reporter_dir, memorably_named_dir
-from ..utils import assert_type, held_out_split, int16_to_float32, select_usable_devices
+from ..utils import (
+    assert_type,
+    int16_to_float32,
+    select_train_val_splits,
+    select_usable_devices,
+)
 
 
 @dataclass
@@ -46,12 +51,13 @@ def evaluate_reporter(
     # saved in float16 to save disk space. In the future we could try to use mixed
     # precision training in at least some cases.
     with dataset.formatted_as("torch", device=device, dtype=torch.int16):
-        train, test = dataset["train"], held_out_split(dataset)
-        test_labels = cast(Tensor, test["label"])
+        train_split, val_split = select_train_val_splits(dataset)
+        train, val = dataset[train_split], dataset[val_split]
+        test_labels = cast(Tensor, val["label"])
 
         _, test_h = normalize(
             int16_to_float32(assert_type(Tensor, train[f"hidden_{layer}"])),
-            int16_to_float32(assert_type(Tensor, test[f"hidden_{layer}"])),
+            int16_to_float32(assert_type(Tensor, val[f"hidden_{layer}"])),
             method=cfg.normalization,
         )
 

--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -3,9 +3,10 @@
 from .prompt_dataset import Prompt, PromptDataset, PromptConfig
 from ..utils import (
     assert_type,
-    infer_label_column,
-    select_usable_devices,
     float32_to_int16,
+    infer_label_column,
+    select_train_val_splits,
+    select_usable_devices,
 )
 from .generator import _GeneratorBuilder
 from dataclasses import dataclass, InitVar
@@ -220,16 +221,7 @@ def extract(cfg: ExtractionConfig, max_gpus: int = -1) -> DatasetDict:
 
     def get_splits() -> SplitDict:
         available_splits = assert_type(SplitDict, info.splits)
-        priorities = {
-            Split.TRAIN: 0,
-            Split.VALIDATION: 1,
-            Split.TEST: 2,
-        }
-        splits = sorted(available_splits, key=lambda k: priorities.get(k, 100))
-        assert len(splits) >= 2, "Must have train and val/test splits"
-
-        # Take the first two splits
-        splits = splits[:2]
+        splits = select_train_val_splits(available_splits)
         print(f"Using '{splits[0]}' for training and '{splits[1]}' for validation")
 
         # Empty list means no limit

--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -219,38 +219,29 @@ def extract(cfg: ExtractionConfig, max_gpus: int = -1) -> DatasetDict:
     """Extract hidden states from a model and return a `DatasetDict` containing them."""
 
     def get_splits() -> SplitDict:
-        # Valid splits: TrVal, TrTe, ValTe, TrValTe(->TrVal)
-        base_splits = assert_type(SplitDict, info.splits)
-        splits = set(base_splits) & {Split.TRAIN, Split.VALIDATION, Split.TEST}
-        if (
-            Split.VALIDATION in splits
-            and Split.TEST in splits
-            and Split.TRAIN in splits
-        ):
-            splits.remove(Split.TEST)
-        assert len(splits) == 2, "Must have at least two of train, val, and test splits"
+        available_splits = assert_type(SplitDict, info.splits)
+        priorities = {
+            Split.TRAIN: 0,
+            Split.VALIDATION: 1,
+            Split.TEST: 2,
+        }
+        splits = sorted(available_splits, key=lambda k: priorities.get(k, 100))
+        assert len(splits) >= 2, "Must have train and val/test splits"
 
-        train_split = Split.TRAIN if Split.TRAIN in splits else Split.VALIDATION
-        val_split = (
-            Split.VALIDATION
-            if Split.VALIDATION and Split.TRAIN in splits
-            else Split.TEST
-        )
+        # Take the first two splits
+        splits = splits[:2]
+        print(f"Using '{splits[0]}' for training and '{splits[1]}' for validation")
 
-        # grab the max number of examples from the config for each split
-        limit = (
-            {
-                train_split: cfg.prompts.max_examples[0],
-                val_split: cfg.prompts.max_examples[0]
-                if len(cfg.prompts.max_examples) == 1
-                else cfg.prompts.max_examples[1],
-            }
-            if cfg.prompts.max_examples
-            else {
-                train_split: int(1e100),
-                val_split: int(1e100),
-            }
-        )
+        # Empty list means no limit
+        limit_list = cfg.prompts.max_examples
+        if not limit_list:
+            limit_list = [int(1e100)]
+
+        # Broadcast the limit to all splits
+        if len(limit_list) == 1:
+            limit_list *= len(splits)
+
+        limit = {k: v for k, v in zip(splits, limit_list)}
         return SplitDict(
             {
                 k: SplitInfo(
@@ -258,10 +249,10 @@ def extract(cfg: ExtractionConfig, max_gpus: int = -1) -> DatasetDict:
                     num_examples=min(limit[k], v.num_examples),
                     dataset_name=v.dataset_name,
                 )
-                for k, v in base_splits.items()
+                for k, v in available_splits.items()
                 if k in splits
             },
-            dataset_name=base_splits.dataset_name,
+            dataset_name=available_splits.dataset_name,
         )
 
     model_cfg = AutoConfig.from_pretrained(cfg.model)

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -2,7 +2,12 @@
 
 from ..extraction import extract, ExtractionConfig
 from ..files import elk_reporter_dir, memorably_named_dir
-from ..utils import assert_type, held_out_split, select_usable_devices, int16_to_float32
+from ..utils import (
+    assert_type,
+    select_train_val_splits,
+    select_usable_devices,
+    int16_to_float32,
+)
 from .classifier import Classifier
 from .ccs_reporter import CcsReporter, CcsReporterConfig
 from .eigen_reporter import EigenReporter, EigenReporterConfig
@@ -73,7 +78,9 @@ def train_reporter(
     # saved in float16 to save disk space. In the future we could try to use mixed
     # precision training in at least some cases.
     with dataset.formatted_as("torch", device=device, dtype=torch.int16):
-        train, val = dataset["train"], held_out_split(dataset)
+        train_split, val_split = select_train_val_splits(dataset)
+        train, val = dataset[train_split], dataset[val_split]
+
         train_labels = cast(Tensor, train["label"])
         val_labels = cast(Tensor, val["label"])
 

--- a/elk/utils/__init__.py
+++ b/elk/utils/__init__.py
@@ -1,11 +1,11 @@
 from .data_utils import (
     compute_class_balance,
-    get_columns_all_equal,
-    held_out_split,
-    infer_label_column,
-    undersample,
     float32_to_int16,
+    get_columns_all_equal,
+    infer_label_column,
     int16_to_float32,
+    select_train_val_splits,
+    undersample,
 )
 from .gpu_utils import select_usable_devices
 from .tree_utils import pytree_map

--- a/elk/utils/data_utils.py
+++ b/elk/utils/data_utils.py
@@ -54,7 +54,7 @@ def select_train_val_splits(raw_splits: Iterable[str]) -> tuple[str, str]:
         Split.TEST: 2,
     }
     splits = sorted(raw_splits, key=lambda k: priorities.get(k, 100))  # type: ignore
-    assert len(splits) >= 2, "Must have train and val/test splits"
+    assert len(splits) >= 2, "Must have at least two of train, val, and test splits"
 
     return tuple(splits[:2])
 

--- a/elk/utils/data_utils.py
+++ b/elk/utils/data_utils.py
@@ -1,7 +1,14 @@
 from .typing import assert_type
-from datasets import ClassLabel, Dataset, DatasetDict, Features, concatenate_datasets
+from datasets import (
+    ClassLabel,
+    Dataset,
+    DatasetDict,
+    Features,
+    Split,
+    concatenate_datasets,
+)
 from random import Random
-from typing import Optional
+from typing import Iterable, Optional
 import numpy as np
 import torch
 
@@ -39,14 +46,17 @@ def get_columns_all_equal(dataset: DatasetDict) -> list[str]:
     return pivot
 
 
-def held_out_split(dataset: DatasetDict) -> Dataset:
-    """Return the validation set if it exits, otherwise the test set."""
-    if "validation" in dataset:
-        return dataset["validation"]
-    elif "test" in dataset:
-        return dataset["test"]
-    else:
-        raise ValueError("No validation or test split found")
+def select_train_val_splits(raw_splits: Iterable[str]) -> tuple[str, str]:
+    """Return splits to use for train and validation, given an Iterable of splits."""
+    priorities = {
+        Split.TRAIN: 0,
+        Split.VALIDATION: 1,
+        Split.TEST: 2,
+    }
+    splits = sorted(raw_splits, key=lambda k: priorities.get(k, 100))  # type: ignore
+    assert len(splits) >= 2, "Must have train and val/test splits"
+
+    return tuple(splits[:2])
 
 
 def infer_label_column(features: Features) -> str:


### PR DESCRIPTION
This PR factors out the logic for determining which splits of a dataset should be used for training & validation into a function in `data_utils.py` called `select_train_val_splits`. This replaces the older `held_out_split` function which was less robust.