### PR TITLE
Support L2 regularization & cross validation for Classifier

### DIFF
--- a/elk/training/classifier.py
+++ b/elk/training/classifier.py
@@ -173,17 +173,6 @@ class Classifier(torch.nn.Module):
         mean_losses = losses.mean(dim=0)
         best_idx = mean_losses.argmin()
 
-        # Check the health of the regularization path- we expect a U shape
-        lhs, rhs = mean_losses[:best_idx], mean_losses[best_idx:]
-        if not len(lhs) or not len(rhs):
-            warnings.warn("The best penalty is at the edge of the regularization path.")
-        else:
-            lhs_monotonic_decreasing = lhs.diff().le(0).all()
-            rhs_monotonic_increasing = rhs.diff().ge(0).all()
-
-            if not lhs_monotonic_decreasing or not rhs_monotonic_increasing:
-                warnings.warn("The regularization path does not have a U shape.")
-
         # Refit with the best penalty
         best_penalty = l2_penalties[best_idx]
         self.fit(x, y, l2_penalty=best_penalty, max_iter=max_iter, tol=tol)

--- a/elk/training/classifier.py
+++ b/elk/training/classifier.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from torch.nn.functional import (
     binary_cross_entropy_with_logits as bce_with_logits,
     cross_entropy,
@@ -5,6 +6,25 @@ from torch.nn.functional import (
 from torch import Tensor
 from typing import Optional
 import torch
+import warnings
+
+
+@dataclass
+class RegularizationPath:
+    """Result of cross-validation."""
+
+    penalties: list[float]
+    losses: list[float]
+
+    @property
+    def best_penalty(self) -> float:
+        """Returns the best L2 regularization penalty."""
+        return self.penalties[self.losses.index(self.best_loss)]
+
+    @property
+    def best_loss(self) -> float:
+        """Returns the best loss."""
+        return min(self.losses)
 
 
 class Classifier(torch.nn.Module):
@@ -28,6 +48,7 @@ class Classifier(torch.nn.Module):
     def forward(self, x: Tensor) -> Tensor:
         return self.linear(x)
 
+    @torch.enable_grad()
     def fit(
         self,
         x: Tensor,
@@ -73,18 +94,101 @@ class Classifier(torch.nn.Module):
             loss = loss_fn(logits, y)
 
             # Add L2 regularization penalty the way scikit-learn does
-            l2_reg = 0.5 * self.linear.weight.data.square().sum()
+            l2_reg = 0.5 * self.linear.weight.square().sum()
 
-            # scikit-learn sums the loss over the number of samples, so this is
-            # equivalent to the L2 regularization penalty being divided by # samples
-            loss += l2_penalty * l2_reg / x.shape[0]
-            loss.backward()
+            reg_loss = loss + l2_penalty * l2_reg
+            reg_loss.backward()
 
-            return float(loss)
+            return float(reg_loss)
 
-        for _ in range(1):
-            optimizer.step(closure)
+        optimizer.step(closure)
         return float(loss)
+
+    @torch.no_grad()
+    def fit_cv(
+        self,
+        x: Tensor,
+        y: Tensor,
+        k: int = 5,
+        *,
+        max_iter: int = 10_000,
+        num_penalties: int = 10,
+        seed: int = 42,
+        tol: float = 1e-4,
+    ) -> RegularizationPath:
+        """Fit using k-fold cross-validation to select the best L2 penalty.
+
+        Args:
+            model: Instance of the Classifier class.
+            x: Input tensor of shape (N, D), where N is the number of samples and D is
+                the input dimension.
+            y: Target tensor of shape (N,) for binary classification or (N, C) for
+                multiclass classification, where C is the number of classes.
+            k: Number of folds for k-fold cross-validation.
+            max_iter: Maximum number of iterations for the L-BFGS optimizer.
+            num_penalties: Number of L2 regularization penalties to try.
+            seed: Random seed for the k-fold cross-validation.
+            tol: Tolerance for the L-BFGS optimizer.
+
+        Returns:
+            `RegularizationPath` containing the penalties tried and the validation loss
+            achieved using that penalty, averaged across the folds.
+        """
+        num_samples = x.shape[0]
+        if k < 3:
+            raise ValueError("`k` must be at least 3")
+        if k > num_samples:
+            raise ValueError("`k` must be less than or equal to the number of samples")
+
+        rng = torch.Generator(device=x.device)
+        rng.manual_seed(seed)
+
+        fold_size = num_samples // k
+        indices = torch.randperm(num_samples, device=x.device, generator=rng)
+
+        l2_penalties = torch.logspace(-4, -4, num_penalties).tolist()
+        y = y.float()
+
+        num_classes = self.linear.out_features
+        loss_fn = bce_with_logits if num_classes == 1 else cross_entropy
+        losses = x.new_zeros((k, num_penalties))
+
+        for i in range(k):
+            start, end = i * fold_size, (i + 1) * fold_size
+            train_indices = torch.cat([indices[:start], indices[end:]])
+            val_indices = indices[start:end]
+
+            train_x, train_y = x[train_indices], y[train_indices]
+            val_x, val_y = x[val_indices], y[val_indices]
+
+            # Regularization path with warm-starting
+            for j, l2_penalty in enumerate(l2_penalties):
+                self.fit(
+                    train_x, train_y, l2_penalty=l2_penalty, max_iter=max_iter, tol=tol
+                )
+
+                logits = self(val_x).squeeze(-1)
+                loss = loss_fn(logits, val_y)
+                losses[i, j] = loss
+
+        mean_losses = losses.mean(dim=0)
+        best_idx = mean_losses.argmin()
+
+        # Check the health of the regularization path- we expect a U shape
+        lhs, rhs = mean_losses[:best_idx], mean_losses[best_idx:]
+        if not len(lhs) or not len(rhs):
+            warnings.warn("The best penalty is at the edge of the regularization path.")
+        else:
+            lhs_monotonic_decreasing = lhs.diff().le(0).all()
+            rhs_monotonic_increasing = rhs.diff().ge(0).all()
+
+            if not lhs_monotonic_decreasing or not rhs_monotonic_increasing:
+                warnings.warn("The regularization path does not have a U shape.")
+
+        # Refit with the best penalty
+        best_penalty = l2_penalties[best_idx]
+        self.fit(x, y, l2_penalty=best_penalty, max_iter=max_iter, tol=tol)
+        return RegularizationPath(l2_penalties, mean_losses.tolist())
 
     def nullspace_project(self, x: Tensor) -> Tensor:
         """Project the given data onto the nullspace of the classifier."""

--- a/elk/training/classifier.py
+++ b/elk/training/classifier.py
@@ -146,7 +146,7 @@ class Classifier(torch.nn.Module):
         fold_size = num_samples // k
         indices = torch.randperm(num_samples, device=x.device, generator=rng)
 
-        l2_penalties = torch.logspace(-4, -4, num_penalties).tolist()
+        l2_penalties = torch.logspace(-4, 4, num_penalties).tolist()
         y = y.float()
 
         num_classes = self.linear.out_features

--- a/elk/training/classifier.py
+++ b/elk/training/classifier.py
@@ -54,7 +54,7 @@ class Classifier(torch.nn.Module):
         x: Tensor,
         y: Tensor,
         *,
-        l2_penalty: float = 1.0,
+        l2_penalty: float = 0.1,
         max_iter: int = 10_000,
         tol: float = 1e-4,
     ) -> float:
@@ -109,8 +109,8 @@ class Classifier(torch.nn.Module):
         self,
         x: Tensor,
         y: Tensor,
-        k: int = 5,
         *,
+        k: int = 5,
         max_iter: int = 10_000,
         num_penalties: int = 10,
         seed: int = 42,
@@ -119,7 +119,6 @@ class Classifier(torch.nn.Module):
         """Fit using k-fold cross-validation to select the best L2 penalty.
 
         Args:
-            model: Instance of the Classifier class.
             x: Input tensor of shape (N, D), where N is the number of samples and D is
                 the input dimension.
             y: Target tensor of shape (N,) for binary classification or (N, C) for

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -132,7 +132,7 @@ def train_reporter(
         X = torch.cat([x0, x1]).squeeze()
         d = X.shape[-1]
         lr_model = Classifier(d, device=device)
-        lr_model.fit(X.view(-1, d), train_labels_aug)
+        lr_model.fit_cv(X.view(-1, d), train_labels_aug)
 
         X_val = torch.cat([val_x0, val_x1]).view(-1, d)
         with torch.no_grad():

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,38 +1,42 @@
 from elk.training.classifier import Classifier
-from elk.utils import assert_type
 from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression
-import numpy as np
 import torch
 
 
+@torch.no_grad()
 def test_classifier_roughly_same_sklearn():
-    input_dims: int = 10
+    input_dims: int = 100
+    torch.manual_seed(0)
 
     # make a classification problem of 1000 samples with input_dims features
-    _features, _truths = make_classification(
+    features, truths = make_classification(
         n_samples=1000, n_features=input_dims, random_state=0
     )
-    # use float32 for the features so it's the same as the default dtype for torch
-    features = assert_type(np.ndarray, _features).astype(np.float32)
-    truths = assert_type(np.ndarray, _truths).astype(np.float32)
 
     # train a logistic regression model on the data. No regularization
-    model = LogisticRegression(penalty=None, solver="lbfgs")  # type: ignore[arg-type]
+    model = LogisticRegression(penalty=None, solver="lbfgs")  # type: ignore[call-arg]
     model.fit(features, truths)
+
     # train a classifier on the data
-    classifier = Classifier(input_dim=input_dims, device="cpu")
-    # float32 is the default dtype for torch tensors
-    classifier.fit(torch.from_numpy(features), torch.from_numpy(truths))
+    classifier = Classifier(input_dim=input_dims, device="cpu", dtype=torch.float64)
+    classifier.fit(
+        torch.from_numpy(features),
+        torch.from_numpy(truths),
+        l2_penalty=0.0,
+    )
     # check that the weights are roughly the same
-    sklearn_coef = model.coef_
-    torch_coef = classifier.linear.weight.detach().numpy()
-    assert np.allclose(sklearn_coef, torch_coef, atol=1e-2)
+    sklearn_coef = torch.from_numpy(model.coef_)
+    torch_coef = classifier.linear.weight.data
+    torch.testing.assert_close(sklearn_coef, torch_coef, atol=1e-2, rtol=1e-2)
 
     # check that on a new sample, the predictions are roughly the same
-    new_sample = np.random.randn(input_dims).astype(np.float32)
+    new_sample = torch.randn(10, input_dims, dtype=torch.float64)
     # 2d array, need to index into the first row and the second column
-    sklearn_pred = model.predict_proba(new_sample.reshape(1, -1))[0][1]
+    sklearn_pred = torch.from_numpy(
+        model.predict_proba(new_sample.numpy())[:, 1]
+    ).squeeze()
     # 1d array, need to index into the first element
-    torch_pred = classifier(torch.from_numpy(new_sample)).sigmoid().detach().numpy()[0]
-    assert np.allclose(sklearn_pred, torch_pred, atol=1e-2)
+    torch_pred = classifier(new_sample).sigmoid().squeeze()
+
+    torch.testing.assert_close(sklearn_pred, torch_pred, atol=1e-2, rtol=1e-2)


### PR DESCRIPTION
This PR adds an `l2_penalty` parameter to `Classifier.fit` with a default value of 0.1— _this is a change_ from the previous behavior, where there was no penalty by default.

I initially tried to exactly imitate the behavior of scikit-learn's `C` inverse regularization parameter, but I couldn't quite figure out how they're computing the final loss. Based on their code it seems like they're doing some weird thing where they're summing the BCE loss over the samples rather than taking the average and this changes the scale of everything, making it dependent on the number of samples. But that didn't seem to give the exact same results either, so idk. I gave up on exactly imitating it— the tests only check that when `l2_penalty` is set to 0.0, the results are ~the same.

This PR also adds a relatively well optimized `fit_cv` method that uses warm-starting to get at least a 2x speed up over a naive approach where you start from a zero initialization every time. I initially wanted to parallelize this code over the folds but this seemed like it would be a real pain in the ass that would complicate the code substantially, and I'm not sure there would be a significant speed boost at the end of the day (at least not without rewriting PyTorch's LBFGS optimizer which I don't want to do right now).

There is a question of whether we want to use `fit_cv` _by default_ in `train.py`. I think we probably should, but it does get us back into the territory where `Classifier` is taking up more compute than the actual VINC algorithm. At the moment the code does use `fit_cv` and doesn't actually give you an option to turn this off (which should probably be changed).