### PR TITLE
Use CuPy sparse eigsh when available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ version = "0.1.1"
 
 [project.optional-dependencies]
 dev = [
+    "cupy-cuda11x",
     "hypothesis",
     "pre-commit",
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ version = "0.1.1"
 
 [project.optional-dependencies]
 dev = [
-    "cupy-cuda11x",
     "hypothesis",
     "pre-commit",
     "pytest",
@@ -48,6 +47,7 @@ dev = [
 elk = "elk.__main__:run"
 
 [tool.pyright]
+exclude = ["elk/training/eigen_reporter.py"]
 include = ["elk*"]
 reportPrivateImportUsage = false
 


### PR DESCRIPTION
This PR changes `EigenReporter.fit_streaming` so that it checks for a CuPy installation and uses `cupyx.scipy.sparse.linalg.eigh` if it is available.