### PR TITLE
Go back to using 1000 datapoints as the default

### DIFF
--- a/elk/extraction/prompt_dataset.py
+++ b/elk/extraction/prompt_dataset.py
@@ -49,10 +49,10 @@ class PromptConfig(Serializable):
     dataset: str = field(positional=True)
     balance: bool = False
     label_column: Optional[str] = None
-    max_examples: list[int] = field(default_factory=list)
+    max_examples: list[int] = field(default_factory=lambda: [750, 250])
     num_shots: int = 0
     seed: int = 42
-    num_variants: int = 1
+    num_variants: int = -1
 
     def __post_init__(self):
         if len(self.max_examples) > 2:


### PR DESCRIPTION
This PR also changes the default `num_variants` to `-1`, meaning we use all the prompt templates by default.