### PR TITLE
split max_examples between processes

### DIFF
--- a/elk/extraction/balanced_sampler.py
+++ b/elk/extraction/balanced_sampler.py
@@ -1,8 +1,9 @@
 from ..math_util import stochastic_round_constrained
 from ..utils import infer_label_column
+from ..utils.typing import assert_type
 from collections import deque
 from dataclasses import dataclass
-from datasets import IterableDataset
+from datasets import IterableDataset, Features
 from itertools import cycle
 from random import Random
 from torch.utils.data import IterableDataset as TorchIterableDataset
@@ -62,7 +63,8 @@ class FewShotSampler:
         label_col: Optional[str] = None,
     ):
         self.dataset = dataset
-        self.label_col = label_col or infer_label_column(dataset.features)
+        feats = assert_type(Features, dataset.features)
+        self.label_col = label_col or infer_label_column(feats)
         self.num_shots = num_shots
         self.rng = rng
 

--- a/elk/logging.py
+++ b/elk/logging.py
@@ -15,10 +15,14 @@ def save_debug_log(ds, out_dir):
         filemode="w",
     )
 
-    _, val_split = select_train_val_splits(ds)
+    train_split, val_split = select_train_val_splits(ds)
     text_inputs = ds[val_split][0]["text_inputs"]
     template_ids = ds[val_split][0]["variant_ids"]
     label = ds[val_split][0]["label"]
+
+    # log the train size and val size
+    logging.info(f"Train size: {len(ds[train_split])}")
+    logging.info(f"Val size: {len(ds[val_split])}")
 
     templates_text = f"{len(text_inputs)} templates used:\n"
     trailing_whitespace = False


### PR DESCRIPTION
Previously the `max_examples` was being multiplied by the number of processes.

After this change, there is no performance degradation from multidatasets:
![image](https://user-images.githubusercontent.com/35092692/228946885-38c6f96d-18ac-4d08-b709-24e7a9dd4ece.png)
