### PR TITLE
Prevent invalidation of the hidden state cache when num_gpus changes

### DIFF
--- a/elk/extraction/generator.py
+++ b/elk/extraction/generator.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Optional
 
 import datasets
+from datasets import Features
 from datasets.splits import NamedSplit
 
 
@@ -10,6 +11,20 @@ class _GeneratorConfig(datasets.BuilderConfig):
     generator: Optional[Callable] = None
     gen_kwargs: dict[str, Any] = field(default_factory=dict)
     features: Optional[datasets.Features] = None
+
+    def create_config_id(
+        self, config_kwargs: dict, custom_features: Features | None
+    ) -> str:
+        # These are implementation details that don't need to be hashed into the id
+        # TODO: Make this customizable or something? Right now we're just hard-coding
+        # these values from extraction.py. OTOH maybe it's not terrible because this is
+        # a private class anyway.
+        gen_kwargs = config_kwargs.get("gen_kwargs", {})
+        gen_kwargs.pop("device", None)
+        gen_kwargs.pop("rank", None)
+        gen_kwargs.pop("world_size", None)
+
+        return super().create_config_id(config_kwargs, custom_features)
 
 
 @dataclass

--- a/elk/training/eigen_reporter.py
+++ b/elk/training/eigen_reporter.py
@@ -180,7 +180,7 @@ class EigenReporter(Reporter):
 
         try:
             L, Q = truncated_eigh(A, k=self.config.num_heads)
-        except ConvergenceError:
+        except (ConvergenceError, RuntimeError):
             warn(
                 "Truncated eigendecomposition failed to converge. Falling back on "
                 "PyTorch's dense eigensolver."


### PR DESCRIPTION
The fix here is moderately hacky; I had to override `create_config_id` in `_GeneratorConfig` to manually remove any trace of the number of GPUs from the generator kwargs before they get hashed.

Fixes #102.