### PR TITLE
add custom_ds_n CLI arg

### DIFF
--- a/elk/evaluation/evaluate.py
+++ b/elk/evaluation/evaluate.py
@@ -41,7 +41,7 @@ class Eval(Serializable):
     num_gpus: int = -1
     skip_baseline: bool = False
     concatenated_layer_offset: int = 0
-    custom_ds_n: Optional[str] = None
+    custom_ds_n: Optional[Path] = None
 
     def execute(self):
         datasets = self.data.prompts.datasets

--- a/elk/evaluation/evaluate.py
+++ b/elk/evaluation/evaluate.py
@@ -41,7 +41,7 @@ class Eval(Serializable):
     num_gpus: int = -1
     skip_baseline: bool = False
     concatenated_layer_offset: int = 0
-    custom_ds_n: str = None
+    custom_ds_n: Optional[str] = None
 
     def execute(self):
         datasets = self.data.prompts.datasets

--- a/elk/evaluation/evaluate.py
+++ b/elk/evaluation/evaluate.py
@@ -41,6 +41,7 @@ class Eval(Serializable):
     num_gpus: int = -1
     skip_baseline: bool = False
     concatenated_layer_offset: int = 0
+    custom_ds_n: str = None
 
     def execute(self):
         datasets = self.data.prompts.datasets
@@ -48,7 +49,9 @@ class Eval(Serializable):
         transfer_dir = elk_reporter_dir() / self.source / "transfer_eval"
 
         for dataset in datasets:
-            run = Evaluate(cfg=self, out_dir=transfer_dir / dataset)
+            run = Evaluate(
+                cfg=self, out_dir=transfer_dir / dataset, custom_ds_n=self.custom_ds_n
+            )
             run.evaluate()
 
 

--- a/elk/run.py
+++ b/elk/run.py
@@ -35,7 +35,7 @@ class Run(ABC):
     cfg: Union["Elicit", "Eval"]
     out_dir: Optional[Path] = None
     dataset: DatasetDict = field(init=False)
-    custom_ds_n: str = None
+    custom_ds_n: Optional[str] = None
 
     def __post_init__(self):
         # Extract the hidden states first if necessary
@@ -45,7 +45,6 @@ class Run(ABC):
             # Save in a memorably-named directory inside of
             # ELK_REPORTER_DIR/<model_name>/<dataset_name>
             ds_name = ", ".join(self.cfg.data.prompts.datasets)
-            print(f"self.custom_root_name: {self.custom_ds_n}")
             if self.custom_ds_n:
                 ds_name = self.custom_ds_n
             root = elk_reporter_dir() / self.cfg.data.model / ds_name

--- a/elk/run.py
+++ b/elk/run.py
@@ -35,6 +35,7 @@ class Run(ABC):
     cfg: Union["Elicit", "Eval"]
     out_dir: Optional[Path] = None
     dataset: DatasetDict = field(init=False)
+    custom_ds_n: str = None
 
     def __post_init__(self):
         # Extract the hidden states first if necessary
@@ -44,6 +45,9 @@ class Run(ABC):
             # Save in a memorably-named directory inside of
             # ELK_REPORTER_DIR/<model_name>/<dataset_name>
             ds_name = ", ".join(self.cfg.data.prompts.datasets)
+            print(f"self.custom_root_name: {self.custom_ds_n}")
+            if self.custom_ds_n:
+                ds_name = self.custom_ds_n
             root = elk_reporter_dir() / self.cfg.data.model / ds_name
 
             self.out_dir = memorably_named_dir(root)

--- a/elk/run.py
+++ b/elk/run.py
@@ -35,7 +35,7 @@ class Run(ABC):
     cfg: Union["Elicit", "Eval"]
     out_dir: Optional[Path] = None
     dataset: DatasetDict = field(init=False)
-    custom_ds_n: Optional[str] = None
+    custom_ds_n: Optional[Path] = None
 
     def __post_init__(self):
         # Extract the hidden states first if necessary

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -56,8 +56,6 @@ class Elicit(Serializable):
     custom_ds_n: str = None
 
     def execute(self):
-        print(f"at train.py the out_dir is currently: {self.out_dir}")
-        print(f"at train.py the custom_root_name is currently: {self.custom_ds_n}")
         train_run = Train(cfg=self, out_dir=self.out_dir, custom_ds_n=self.custom_ds_n)
         train_run.train()
 

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -53,9 +53,12 @@ class Elicit(Serializable):
     # if nonzero, appends the hidden states of layer concatenated_layer_offset before
     debug: bool = False
     out_dir: Optional[Path] = None
+    custom_ds_n: str = None
 
     def execute(self):
-        train_run = Train(cfg=self, out_dir=self.out_dir)
+        print(f"at train.py the out_dir is currently: {self.out_dir}")
+        print(f"at train.py the custom_root_name is currently: {self.custom_ds_n}")
+        train_run = Train(cfg=self, out_dir=self.out_dir, custom_ds_n=self.custom_ds_n)
         train_run.train()
 
 

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -53,7 +53,7 @@ class Elicit(Serializable):
     # if nonzero, appends the hidden states of layer concatenated_layer_offset before
     debug: bool = False
     out_dir: Optional[Path] = None
-    custom_ds_n: str = None
+    custom_ds_n: Optional[Path] = None
 
     def execute(self):
         train_run = Train(cfg=self, out_dir=self.out_dir, custom_ds_n=self.custom_ds_n)


### PR DESCRIPTION
Allows ``--custom_ds_n [custom_name]`` to shorten long naming from multiple datasets  

Unmodified, the output path to eliciting with datasets ``super_glue boolq`` and ``christykoh/boolq_pt`` 
``elk-reporters/bigscience/bloomz-7b1-mt/christykoh/boolq_pt, super_glue boolq/quizzical-mccarthy``

To cd to this reporter requires, ``elk-reporters/bigscience/bloomz-7b1-mt/christykoh/"boolq_pt, super_glue boolq"/quizzical-mccarthy`` where path is divided with arbitrary number of ``/`` in the datasets as opposed to where datasets are actually divided 

You can use this keyword when running ``elk elicit``/``eval`` without typing the full path to group the experiments by datasets, such as in the example above, ``--custom_ds_n multiboolq`` to get ``elk-reporters/bigscience/bloomz-7b1-mt/multiboolq/quizzical-mccarthy``