### PR TITLE
Clean up train and eval commands; do transfer eval in sweep

### DIFF
--- a/elk/evaluation/evaluate.py
+++ b/elk/evaluation/evaluate.py
@@ -1,70 +1,36 @@
 from dataclasses import dataclass
-from functools import partial
-from pathlib import Path
-from typing import Callable
 
 import pandas as pd
 import torch
-from simple_parsing.helpers import Serializable, field
+from simple_parsing.helpers import field
 
-from ..extraction.extraction import Extract
 from ..files import elk_reporter_dir
 from ..metrics import evaluate_preds
 from ..run import Run
 from ..training import Reporter
-from ..utils import select_usable_devices
 
 
 @dataclass
-class Eval(Serializable):
-    """
-    Full specification of a reporter evaluation run.
+class Eval(Run):
+    """Full specification of a reporter evaluation run."""
 
-    Args:
-        data: Config specifying hidden states on which the reporter will be evaluated.
-        source: The name of the source run directory
-            which contains the reporters directory.
-        normalization: The normalization method to use. Defaults to "meanonly". See
-            `elk.training.preprocessing.normalize()` for details.
-        num_gpus: The number of GPUs to use. Defaults to -1, which means
-            "use all available GPUs".
-        skip_supervised: Whether to skip evaluation of the supervised classifier.
-        debug: When in debug mode, a useful log file is saved to the memorably-named
-            output directory. Defaults to False.
-    """
-
-    data: Extract
-    source: str = field(positional=True)
-
-    concatenated_layer_offset: int = 0
-    debug: bool = False
-    min_gpu_mem: int | None = None
-    num_gpus: int = -1
-    out_dir: Path | None = None
+    source: str = field(default="", positional=True)
     skip_supervised: bool = False
 
-    disable_cache: bool = field(default=False, to_dict=False)
+    def __post_init__(self):
+        assert self.source, "Must specify a source experiment."
 
-    def execute(self):
         transfer_dir = elk_reporter_dir() / self.source / "transfer_eval"
+        self.out_dir = transfer_dir / "+".join(self.data.prompts.datasets)
 
-        for dataset in self.data.prompts.datasets:
-            run = Evaluate(cfg=self, out_dir=transfer_dir / dataset)
-            run.evaluate()
-
-
-@dataclass
-class Evaluate(Run):
-    cfg: Eval
-
-    def evaluate_reporter(
-        self, layer: int, devices: list[str], world_size: int = 1
+    def apply_to_layer(
+        self, layer: int, devices: list[str], world_size: int
     ) -> pd.DataFrame:
         """Evaluate a single reporter on a single layer."""
         device = self.get_device(devices, world_size)
         val_output = self.prepare_data(device, layer, "val")
 
-        experiment_dir = elk_reporter_dir() / self.cfg.source
+        experiment_dir = elk_reporter_dir() / self.source
 
         reporter_path = experiment_dir / "reporters" / f"layer_{layer}.pt"
         reporter: Reporter = torch.load(reporter_path, map_location=device)
@@ -81,7 +47,7 @@ class Evaluate(Run):
             }
 
             lr_dir = experiment_dir / "lr_models"
-            if not self.cfg.skip_supervised and lr_dir.exists():
+            if not self.skip_supervised and lr_dir.exists():
                 with open(lr_dir / f"layer_{layer}.pt", "rb") as f:
                     lr_model = torch.load(f, map_location=device).eval()
 
@@ -91,15 +57,3 @@ class Evaluate(Run):
             row_buf.append(stats_row)
 
         return pd.DataFrame.from_records(row_buf)
-
-    def evaluate(self):
-        """Evaluate the reporter on all layers."""
-        devices = select_usable_devices(
-            self.cfg.num_gpus, min_memory=self.cfg.min_gpu_mem
-        )
-
-        num_devices = len(devices)
-        func: Callable[[int], pd.DataFrame] = partial(
-            self.evaluate_reporter, devices=devices, world_size=num_devices
-        )
-        self.apply_to_layers(func=func, num_devices=num_devices)

--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -28,6 +28,7 @@ from transformers.modeling_outputs import Seq2SeqLMOutput
 from ..promptsource import DatasetTemplates
 from ..utils import (
     assert_type,
+    colorize,
     float32_to_int16,
     infer_label_column,
     infer_num_classes,
@@ -271,6 +272,7 @@ def extract(
     cfg: "Extract",
     *,
     disable_cache: bool = False,
+    highlight_color: str = "cyan",
     num_gpus: int = -1,
     min_gpu_mem: int | None = None,
 ) -> DatasetDict:
@@ -279,10 +281,11 @@ def extract(
     def get_splits() -> SplitDict:
         available_splits = assert_type(SplitDict, info.splits)
         train_name, val_name = select_train_val_splits(available_splits)
+
+        pretty_name = colorize(assert_type(str, info.builder_name), highlight_color)
         print(
-            # Cyan color for dataset name
-            f"\033[36m{info.builder_name}\033[0m: using '{train_name}' for training and"
-            f" '{val_name}' for validation"
+            f"{pretty_name}: using '{train_name}' for training "
+            f"and '{val_name}' for validation"
         )
         limit_list = cfg.prompts.max_examples
 

--- a/elk/run.py
+++ b/elk/run.py
@@ -1,9 +1,10 @@
 import os
 import random
-from abc import ABC
-from dataclasses import dataclass, field
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Literal, Union
+from typing import Callable, Literal
 
 import numpy as np
 import pandas as pd
@@ -11,11 +12,12 @@ import torch
 import torch.multiprocessing as mp
 import yaml
 from datasets import DatasetDict
+from simple_parsing.helpers import Serializable, field
 from torch import Tensor
 from tqdm import tqdm
 
 from .debug_logging import save_debug_log
-from .extraction import extract
+from .extraction import Extract, extract
 from .files import elk_reporter_dir, memorably_named_dir
 from .utils import (
     assert_type,
@@ -23,35 +25,44 @@ from .utils import (
     get_layers,
     int16_to_float32,
     select_train_val_splits,
+    select_usable_devices,
 )
-
-if TYPE_CHECKING:
-    from .evaluation.evaluate import Eval
-    from .training.train import Elicit
 
 
 @dataclass
-class Run(ABC):
-    cfg: Union["Elicit", "Eval"]
+class Run(ABC, Serializable):
+    data: Extract
     out_dir: Path | None = None
-    datasets: list[DatasetDict] = field(init=False)
+    """Directory to save results to. If None, a directory will be created
+    automatically."""
 
-    def __post_init__(self):
+    datasets: list[DatasetDict] = field(default_factory=list, init=False)
+    """Datasets containing hidden states and labels for each layer."""
+
+    concatenated_layer_offset: int = 0
+    debug: bool = False
+    min_gpu_mem: int | None = None
+    num_gpus: int = -1
+    out_dir: Path | None = None
+    disable_cache: bool = field(default=False, to_dict=False)
+
+    def execute(self, highlight_color: str = "cyan"):
         self.datasets = [
             extract(
                 cfg,
-                disable_cache=self.cfg.disable_cache,
-                num_gpus=self.cfg.num_gpus,
-                min_gpu_mem=self.cfg.min_gpu_mem,
+                disable_cache=self.disable_cache,
+                highlight_color=highlight_color,
+                num_gpus=self.num_gpus,
+                min_gpu_mem=self.min_gpu_mem,
             )
-            for cfg in self.cfg.data.explode()
+            for cfg in self.data.explode()
         ]
 
         if self.out_dir is None:
             # Save in a memorably-named directory inside of
             # ELK_REPORTER_DIR/<model_name>/<dataset_name>
-            ds_name = ", ".join(self.cfg.data.prompts.datasets)
-            root = elk_reporter_dir() / self.cfg.data.model / ds_name
+            ds_name = ", ".join(self.data.prompts.datasets)
+            root = elk_reporter_dir() / self.data.model / ds_name
 
             self.out_dir = memorably_named_dir(root)
 
@@ -61,7 +72,7 @@ class Run(ABC):
 
         path = self.out_dir / "cfg.yaml"
         with open(path, "w") as f:
-            self.cfg.dump_yaml(f)
+            self.dump_yaml(f)
 
         path = self.out_dir / "fingerprints.yaml"
         with open(path, "w") as meta_f:
@@ -74,6 +85,19 @@ class Run(ABC):
                 },
                 meta_f,
             )
+
+        devices = select_usable_devices(self.num_gpus, min_memory=self.min_gpu_mem)
+        num_devices = len(devices)
+        func: Callable[[int], pd.DataFrame] = partial(
+            self.apply_to_layer, devices=devices, world_size=num_devices
+        )
+        self.apply_to_layers(func=func, num_devices=num_devices)
+
+    @abstractmethod
+    def apply_to_layer(
+        self, layer: int, devices: list[str], world_size: int
+    ) -> pd.DataFrame:
+        """Train or eval a reporter on a single layer."""
 
     def make_reproducible(self, seed: int):
         """Make the run reproducible by setting the random seed."""
@@ -114,8 +138,8 @@ class Run(ABC):
 
     def concatenate(self, layers):
         """Concatenate hidden states from a previous layer."""
-        for layer in range(self.cfg.concatenated_layer_offset, len(layers)):
-            layers[layer] += [layers[layer][0] - self.cfg.concatenated_layer_offset]
+        for layer in range(self.concatenated_layer_offset, len(layers)):
+            layers[layer] += [layers[layer][0] - self.concatenated_layer_offset]
 
         return layers
 
@@ -137,10 +161,9 @@ class Run(ABC):
         layers, *rest = [get_layers(ds) for ds in self.datasets]
         assert all(x == layers for x in rest), "All datasets must have the same layers"
 
-        if self.cfg.concatenated_layer_offset > 0:
+        if self.concatenated_layer_offset > 0:
             layers = self.concatenate(layers)
 
-        # Should we write to different CSV files for elicit vs eval?
         ctx = mp.get_context("spawn")
         with ctx.Pool(num_devices) as pool, open(self.out_dir / "eval.csv", "w") as f:
             mapper = pool.imap_unordered if num_devices > 1 else map
@@ -154,5 +177,5 @@ class Run(ABC):
                 if df_buf:
                     df = pd.concat(df_buf).sort_values(by="layer")
                     df.round(4).to_csv(f, index=False)
-                if self.cfg.debug:
+                if self.debug:
                     save_debug_log(self.datasets, self.out_dir)

--- a/elk/training/__init__.py
+++ b/elk/training/__init__.py
@@ -2,7 +2,7 @@ from .ccs_reporter import CcsReporter, CcsReporterConfig
 from .classifier import Classifier
 from .eigen_reporter import EigenReporter, EigenReporterConfig
 from .normalizer import Normalizer
-from .reporter import OptimConfig, Reporter, ReporterConfig
+from .reporter import Reporter, ReporterConfig
 
 __all__ = [
     "CcsReporter",
@@ -11,7 +11,6 @@ __all__ = [
     "EigenReporter",
     "EigenReporterConfig",
     "Normalizer",
-    "OptimConfig",
     "Reporter",
     "ReporterConfig",
 ]

--- a/elk/training/eigen_reporter.py
+++ b/elk/training/eigen_reporter.py
@@ -213,7 +213,7 @@ class EigenReporter(Reporter):
         )
 
         if truncated:
-            L, Q = truncated_eigh(A, k=self.config.num_heads)
+            L, Q = truncated_eigh(A, k=self.config.num_heads, seed=self.config.seed)
         else:
             try:
                 L, Q = torch.linalg.eigh(A)

--- a/elk/training/reporter.py
+++ b/elk/training/reporter.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -19,25 +19,6 @@ class ReporterConfig(Serializable):
     """
 
     seed: int = 42
-
-
-@dataclass
-class OptimConfig(Serializable):
-    """
-    Args:
-        lr: The learning rate to use. Ignored when `optimizer` is `"lbfgs"`.
-            Defaults to 1e-2.
-        num_epochs: The number of epochs to train for. Defaults to 1000.
-        num_tries: The number of times to try training the reporter. Defaults to 10.
-        optimizer: The optimizer to use. Defaults to "adam".
-        weight_decay: The weight decay or L2 penalty to use. Defaults to 0.01.
-    """
-
-    lr: float = 1e-2
-    num_epochs: int = 1000
-    num_tries: int = 10
-    optimizer: Literal["adam", "lbfgs"] = "lbfgs"
-    weight_decay: float = 0.01
 
 
 class Reporter(nn.Module, ABC):

--- a/elk/training/sweep.py
+++ b/elk/training/sweep.py
@@ -1,8 +1,10 @@
 from copy import deepcopy
 from dataclasses import InitVar, dataclass
 
+from ..evaluation.evaluate import Eval
 from ..extraction import Extract, PromptConfig
 from ..files import elk_reporter_dir, memorably_named_dir
+from ..utils import colorize
 from .train import Elicit
 
 
@@ -47,6 +49,19 @@ class Sweep:
         sweep_dir = root_dir / self.name if self.name else memorably_named_dir(root_dir)
         print(f"Saving sweep results to \033[1m{sweep_dir}\033[0m")  # bold
 
+        # Each dataset string can contain multiple datasets, delimited by plus; this
+        # indicates that the component datasets will be pooled together for training.
+        # For example, we might be sweeping over ["amazon_polarity", "imdb+sst2"]. For
+        # transfer eval, we want to split "imdb+sst2" into ["imdb", "sst2"] and then
+        # flatten the list, yielding ["amazon_polarity", "imdb", "sst2"].
+        eval_datasets = sorted(
+            {
+                ds.strip()
+                for dataset_str in self.datasets
+                for ds in dataset_str.split("+")
+            }
+        )
+
         for i, model_str in enumerate(self.models):
             # Magenta color for the model name
             print(f"\n\033[35m===== {model_str} ({i + 1} of {M}) =====\033[0m")
@@ -57,10 +72,29 @@ class Sweep:
                 # Allow for multiple datasets to be specified in a single string with
                 # plus signs. This means we can pool datasets together inside of a
                 # single sweep.
-                datasets = [ds.strip() for ds in dataset_str.split("+")]
+                train_datasets = [ds.strip() for ds in dataset_str.split("+")]
 
                 run = deepcopy(self.run_template)
                 run.data.model = model_str
-                run.data.prompts.datasets = datasets
+                run.data.prompts.datasets = train_datasets
                 run.out_dir = out_dir
                 run.execute()
+
+                if len(eval_datasets) > 1:
+                    print(colorize("== Transfer eval ==", "green"))
+
+                # Now evaluate the reporter on the other datasets
+                for eval_dataset in eval_datasets:
+                    # We already evaluated on this one during training
+                    if eval_dataset in train_datasets:
+                        continue
+
+                    eval = Eval(
+                        data=Extract(
+                            model=model_str,
+                            prompts=PromptConfig(datasets=[eval_dataset]),
+                        ),
+                        source=str(run.out_dir),
+                        out_dir=out_dir,
+                    )
+                    eval.execute(highlight_color="green")

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -1,67 +1,36 @@
 """Main training loop."""
 
 from dataclasses import dataclass
-from functools import partial
 from pathlib import Path
-from typing import Callable, Literal
+from typing import Literal
 
 import pandas as pd
 import torch
 from einops import rearrange, repeat
-from simple_parsing import Serializable, field, subgroups
+from simple_parsing import subgroups
 
-from ..extraction.extraction import Extract
 from ..metrics import evaluate_preds, to_one_hot
 from ..run import Run
 from ..training.supervised import train_supervised
-from ..utils import select_usable_devices
 from ..utils.typing import assert_type
 from .ccs_reporter import CcsReporter, CcsReporterConfig
 from .eigen_reporter import EigenReporter, EigenReporterConfig
-from .reporter import OptimConfig, ReporterConfig
+from .reporter import ReporterConfig
 
 
 @dataclass
-class Elicit(Serializable):
-    """Full specification of a reporter training run.
+class Elicit(Run):
+    """Full specification of a reporter training run."""
 
-    Args:
-        data: Config specifying hidden states on which the reporter will be trained.
-        net: Config for building the reporter network.
-        optim: Config for the `.fit()` loop.
-        num_gpus: The number of GPUs to use. Defaults to -1, which means
-            "use all available GPUs".
-        normalization: The normalization method to use. Defaults to "meanonly". See
-            `elk.training.preprocessing.normalize()` for details.
-        supervised: Whether to train a supervised classifier, and if so, whether to
-            use cross-validation. Defaults to "single", which means to train a single
-            classifier on the training data. "cv" means to use cross-validation.
-        debug: When in debug mode, a useful log file is saved to the memorably-named
-            output directory. Defaults to False.
-    """
-
-    data: Extract
     net: ReporterConfig = subgroups(
         {"ccs": CcsReporterConfig, "eigen": EigenReporterConfig}, default="eigen"
     )
-    optim: OptimConfig = field(default_factory=OptimConfig)
+    """Config for building the reporter network."""
 
-    concatenated_layer_offset: int = 0
-    debug: bool = False
-    min_gpu_mem: int | None = None
-    num_gpus: int = -1
-    out_dir: Path | None = None
     supervised: Literal["none", "single", "cv"] = "single"
-
-    disable_cache: bool = field(default=False, to_dict=False)
-
-    def execute(self):
-        Train(cfg=self, out_dir=self.out_dir).train()
-
-
-@dataclass
-class Train(Run):
-    cfg: Elicit
+    """Whether to train a supervised classifier, and if so, whether to use
+    cross-validation. Defaults to "single", which means to train a single classifier
+    on the training data. "cv" means to use cross-validation."""
 
     def create_models_dir(self, out_dir: Path):
         lr_dir = None
@@ -73,14 +42,15 @@ class Train(Run):
 
         return reporter_dir, lr_dir
 
-    def train_reporter(
+    def apply_to_layer(
         self,
         layer: int,
         devices: list[str],
-        world_size: int = 1,
+        world_size: int,
     ) -> pd.DataFrame:
         """Train a single reporter on a single layer."""
-        self.make_reproducible(seed=self.cfg.net.seed + layer)
+
+        self.make_reproducible(seed=self.net.seed + layer)
         device = self.get_device(devices, world_size)
 
         train_dict = self.prepare_data(device, layer, "train")
@@ -92,10 +62,10 @@ class Train(Run):
             raise ValueError("All datasets must have the same hidden state size")
 
         reporter_dir, lr_dir = self.create_models_dir(assert_type(Path, self.out_dir))
-        if isinstance(self.cfg.net, CcsReporterConfig):
+        if isinstance(self.net, CcsReporterConfig):
             assert len(train_dict) == 1, "CCS only supports single-task training"
 
-            reporter = CcsReporter(self.cfg.net, d, device=device)
+            reporter = CcsReporter(self.net, d, device=device)
             train_loss = reporter.fit(first_train_h, train_labels)
 
             (val_h, val_gt, _) = next(iter(val_dict.values()))
@@ -106,11 +76,11 @@ class Train(Run):
                 val_pair=(reporter.neg_norm(val_x0), reporter.pos_norm(val_x1)),
             )
 
-        elif isinstance(self.cfg.net, EigenReporterConfig):
+        elif isinstance(self.net, EigenReporterConfig):
             # We set num_classes to None to enable training on datasets with different
             # numbers of classes. Under the hood, this causes the covariance statistics
             # to be simply averaged across all batches passed to update().
-            reporter = EigenReporter(self.cfg.net, d, num_classes=None, device=device)
+            reporter = EigenReporter(self.net, d, num_classes=None, device=device)
 
             hidden_list, label_list = [], []
             for ds_name, (train_h, train_labels, _) in train_dict.items():
@@ -131,16 +101,16 @@ class Train(Run):
                 torch.cat(hidden_list),
             )
         else:
-            raise ValueError(f"Unknown reporter config type: {type(self.cfg.net)}")
+            raise ValueError(f"Unknown reporter config type: {type(self.net)}")
 
         # Save reporter checkpoint to disk
         with open(reporter_dir / f"layer_{layer}.pt", "wb") as file:
             torch.save(reporter, file)
 
         # Fit supervised logistic regression model
-        if self.cfg.supervised != "none":
+        if self.supervised != "none":
             lr_model = train_supervised(
-                train_dict, device=device, cv=self.cfg.supervised == "cv"
+                train_dict, device=device, cv=self.supervised == "cv"
             )
             with open(lr_dir / f"layer_{layer}.pt", "wb") as file:
                 torch.save(lr_model, file)
@@ -169,12 +139,3 @@ class Train(Run):
             row_buf.append(row)
 
         return pd.DataFrame.from_records(row_buf)
-
-    def train(self):
-        """Train a reporter on each layer of the network."""
-        devices = select_usable_devices(self.cfg.num_gpus)
-        num_devices = len(devices)
-        func: Callable[[int], pd.DataFrame] = partial(
-            self.train_reporter, devices=devices, world_size=num_devices
-        )
-        self.apply_to_layers(func=func, num_devices=num_devices)

--- a/elk/truncated_eigh.py
+++ b/elk/truncated_eigh.py
@@ -16,7 +16,6 @@ class Eigendecomposition(NamedTuple):
     eigenvectors: Tensor
 
 
-@torch.autocast("cuda", enabled=torch.cuda.is_available())
 def truncated_eigh(
     A: Tensor,
     k: int = 1,

--- a/elk/utils/__init__.py
+++ b/elk/utils/__init__.py
@@ -11,6 +11,7 @@ from .data_utils import (
 from .gpu_utils import select_usable_devices
 from .hf_utils import instantiate_model, instantiate_tokenizer, is_autoregressive
 from .math_util import batch_cov, cov_mean_fused, stochastic_round_constrained
+from .pretty import colorize
 from .tree_utils import pytree_map
 from .typing import assert_type, float32_to_int16, int16_to_float32
 
@@ -18,6 +19,7 @@ __all__ = [
     "assert_type",
     "batch_cov",
     "binarize",
+    "colorize",
     "cov_mean_fused",
     "float32_to_int16",
     "get_columns_all_equal",

--- a/elk/utils/pretty.py
+++ b/elk/utils/pretty.py
@@ -1,0 +1,24 @@
+# Kind of kickass that this file has no imports
+
+# ANSI color codes for use in terminal output.
+COLOR_CODES = {
+    "black": 30,
+    "red": 31,
+    "green": 32,
+    "yellow": 33,
+    "blue": 34,
+    "magenta": 35,
+    "cyan": 36,
+    "white": 37,
+}
+
+
+def colorize(message: str, color: str) -> str:
+    """Colorize a message for terminal output."""
+    # Get the ANSI color code based on the human-readable color name.
+    code = COLOR_CODES.get(color.lower())
+    if code is None:
+        raise ValueError(f"Invalid color name: {color}")
+
+    # Construct and return the colored message.
+    return f"\033[{code}m{message}\033[0m"


### PR DESCRIPTION
Merged `Train` and `Evaluate` classes into their corresponding config classes; removed duplicate code; made the sweep command also run transfer eval on all pairs