### PR TITLE
add pdbpp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "pytest",
     "pyright",
     "scikit-learn",
+    "pdbpp"
 ]
 
 [project.scripts]


### PR DESCRIPTION
"This module is an extension of the [pdb](http://docs.python.org/library/pdb.html) module of the standard library. It is meant to be fully compatible with its predecessor, yet it introduces a number of new features to make your debugging experience as nice as possible."
The "sticky" feature is quite useful for example
https://pypi.org/project/pdbpp/