### PR TITLE
Log ensembled metrics

### DIFF
--- a/elk/evaluation/evaluate.py
+++ b/elk/evaluation/evaluate.py
@@ -45,21 +45,32 @@ class Eval(Run):
         for ds_name, (val_h, val_gt, _) in val_output.items():
             meta = {"dataset": ds_name, "layer": layer}
 
-            val_result = evaluate_preds(val_gt, reporter(val_h))
-            row_bufs["eval"].append({**meta, **val_result.to_dict()})
+            val_credences = reporter(val_h)
+            for mode in ("none", "partial", "full"):
+                row_bufs["eval"].append(
+                    {
+                        **meta,
+                        "ensembling": mode,
+                        **evaluate_preds(val_gt, val_credences, mode).to_dict(),
+                    }
+                )
 
-            lr_dir = experiment_dir / "lr_models"
-            if not self.skip_supervised and lr_dir.exists():
-                with open(lr_dir / f"layer_{layer}.pt", "rb") as f:
-                    lr_models = torch.load(f, map_location=device)
-                    if not isinstance(lr_models, list):  # backward compatibility
-                        lr_models = [lr_models]
+                lr_dir = experiment_dir / "lr_models"
+                if not self.skip_supervised and lr_dir.exists():
+                    with open(lr_dir / f"layer_{layer}.pt", "rb") as f:
+                        lr_models = torch.load(f, map_location=device)
+                        if not isinstance(lr_models, list):  # backward compatibility
+                            lr_models = [lr_models]
 
-                for i, model in enumerate(lr_models):
-                    model.eval()
-                    lr_result = evaluate_preds(val_gt, model(val_h))
-                    row_bufs["lr_eval"].append(
-                        {"inlp_iter": i, **meta, **lr_result.to_dict()}
-                    )
+                    for i, model in enumerate(lr_models):
+                        model.eval()
+                        row_bufs["lr_eval"].append(
+                            {
+                                "ensembling": mode,
+                                "inlp_iter": i,
+                                **meta,
+                                **evaluate_preds(val_gt, model(val_h), mode).to_dict(),
+                            }
+                        )
 
         return {k: pd.DataFrame(v) for k, v in row_bufs.items()}

--- a/elk/run.py
+++ b/elk/run.py
@@ -173,7 +173,7 @@ class Run(ABC, Serializable):
             finally:
                 # Make sure the CSVs are written even if we crash or get interrupted
                 for name, dfs in df_buffers.items():
-                    df = pd.concat(dfs).sort_values(by="layer")
+                    df = pd.concat(dfs).sort_values(by=["layer", "ensembling"])
                     df.round(4).to_csv(self.out_dir / f"{name}.csv", index=False)
                 if self.debug:
                     save_debug_log(self.datasets, self.out_dir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
     "hypothesis",
     "pre-commit",
     "pytest",
-    "pyright",
+    "pyright==1.1.304",
     "scikit-learn",
 ]
 


### PR DESCRIPTION
This PR introduces three "modes" for ensembling the different credences output by a reporter for a single cluster or datapoint.

1. `none` is no ensembling, or what we do right now.
2. `partial` means we ensemble across contrast pairs, similar to what was done in the DLK paper. Specifically, the ensembled credence is `pos - neg` where `pos` is the credence on the positive pseudolabel and `neg` is the credence on the negative pseudolabel. 
3. `full` ensembles both across contrast pairs _and_ across different prompt templates. Specifically, we take the average of the credences computed across all prompt templates and use that as the prediction for the cluster.

These are implemented as options on the `evaluate_preds` function. The `elicit` and `eval` commands log metrics for all 3 values.

It turns out this ensembling can matter quite a bit; `full` is often on the order of 10 percentage points higher AUROC / acc than `none`.