### PR TITLE
Reduce VINC reporter file size by >1000x

### DIFF
--- a/elk/evaluation/evaluate.py
+++ b/elk/evaluation/evaluate.py
@@ -38,7 +38,7 @@ class Eval(Run):
         experiment_dir = elk_reporter_dir() / self.source
 
         reporter_path = experiment_dir / "reporters" / f"layer_{layer}.pt"
-        reporter: Reporter = torch.load(reporter_path, map_location=device)
+        reporter = Reporter.load(reporter_path, map_location=device)
         reporter.eval()
 
         row_bufs = defaultdict(list)

--- a/elk/run.py
+++ b/elk/run.py
@@ -41,7 +41,7 @@ class Run(ABC, Serializable):
 
     concatenated_layer_offset: int = 0
     debug: bool = False
-    min_gpu_mem: int | None = None
+    min_gpu_mem: int | None = None  # in bytes
     num_gpus: int = -1
     out_dir: Path | None = None
     disable_cache: bool = field(default=False, to_dict=False)

--- a/elk/run.py
+++ b/elk/run.py
@@ -13,6 +13,7 @@ import torch
 import torch.multiprocessing as mp
 import yaml
 from simple_parsing.helpers import Serializable, field
+from simple_parsing.helpers.serialization import save
 from torch import Tensor
 from tqdm import tqdm
 
@@ -36,7 +37,9 @@ class Run(ABC, Serializable):
     """Directory to save results to. If None, a directory will be created
     automatically."""
 
-    datasets: list[DatasetDictWithName] = field(default_factory=list, init=False)
+    datasets: list[DatasetDictWithName] = field(
+        default_factory=list, init=False, to_dict=False
+    )
     """Datasets containing hidden states and labels for each layer."""
 
     concatenated_layer_offset: int = 0
@@ -70,9 +73,9 @@ class Run(ABC, Serializable):
         print(f"Output directory at \033[1m{self.out_dir}\033[0m")
         self.out_dir.mkdir(parents=True, exist_ok=True)
 
-        path = self.out_dir / "cfg.yaml"
-        with open(path, "w") as f:
-            self.dump_yaml(f)
+        # save_dc_types really ought to be the default... We simply can't load
+        # properly without this flag enabled.
+        save(self, self.out_dir / "cfg.yaml", save_dc_types=True)
 
         path = self.out_dir / "fingerprints.yaml"
         with open(path, "w") as meta_f:

--- a/elk/training/ccs_reporter.py
+++ b/elk/training/ccs_reporter.py
@@ -3,6 +3,7 @@
 import math
 from copy import deepcopy
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Literal, Optional, cast
 
 import torch
@@ -59,7 +60,6 @@ class CcsReporterConfig(ReporterConfig):
     loss_dict: dict[str, float] = field(default_factory=dict, init=False)
     num_layers: int = 1
     pre_ln: bool = False
-    seed: int = 42
     supervised_weight: float = 0.0
 
     lr: float = 1e-2
@@ -67,6 +67,10 @@ class CcsReporterConfig(ReporterConfig):
     num_tries: int = 10
     optimizer: Literal["adam", "lbfgs"] = "lbfgs"
     weight_decay: float = 0.01
+
+    @classmethod
+    def reporter_class(cls) -> type[Reporter]:
+        return CcsReporter
 
     def __post_init__(self):
         self.loss_dict = parse_loss(self.loss)
@@ -94,6 +98,11 @@ class CcsReporter(Reporter):
     ):
         super().__init__()
         self.config = cfg
+        self.in_features = in_features
+
+        # Learnable Platt scaling parameters
+        self.bias = nn.Parameter(torch.zeros(1, device=device, dtype=dtype))
+        self.scale = nn.Parameter(torch.ones(1, device=device, dtype=dtype))
 
         hidden_size = cfg.hidden_size or 4 * in_features // 3
 
@@ -220,7 +229,7 @@ class CcsReporter(Reporter):
 
     def forward(self, x: Tensor) -> Tensor:
         """Return the raw score output of the probe on `x`."""
-        return self.probe(x).squeeze(-1)
+        return self.probe(x).mul(self.scale).add(self.bias).squeeze(-1)
 
     def loss(
         self,
@@ -379,3 +388,9 @@ class CcsReporter(Reporter):
 
         optimizer.step(closure)
         return float(loss)
+
+    def save(self, path: Path | str) -> None:
+        """Save the reporter to a file."""
+        state = {k: v.cpu() for k, v in self.state_dict().items()}
+        state.update(in_features=self.in_features)
+        torch.save(state, path)

--- a/elk/training/eigen_reporter.py
+++ b/elk/training/eigen_reporter.py
@@ -29,6 +29,7 @@ class EigenReporterConfig(ReporterConfig):
     neg_cov_weight: float = 0.5
 
     num_heads: int = 1
+    save_reporter_stats: bool = False
 
     def __post_init__(self):
         if not (0 <= self.neg_cov_weight <= 1):
@@ -312,8 +313,8 @@ class EigenReporter(Reporter):
 
         opt.step(closure)
 
-    def save(self, path: Path | str, save_stats=False):
+    def save(self, path: Path | str):
         # TODO: this method will save separate JSON and PT files
-        if not save_stats:
+        if not self.config.save_reporter_stats:
             self.delete_stats()
         super().save(path)

--- a/elk/training/eigen_reporter.py
+++ b/elk/training/eigen_reporter.py
@@ -2,13 +2,11 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 import torch
-from einops import rearrange, repeat
-from torch import Tensor, nn, optim
+from einops import rearrange
+from torch import Tensor, nn
 
-from ..metrics import to_one_hot
 from ..truncated_eigh import truncated_eigh
 from ..utils.math_util import cov_mean_fused
 from .reporter import Reporter, ReporterConfig
@@ -16,26 +14,30 @@ from .reporter import Reporter, ReporterConfig
 
 @dataclass
 class EigenReporterConfig(ReporterConfig):
-    """Configuration for an EigenReporter.
+    """Configuration for an EigenReporter."""
 
-    Args:
-        var_weight: The weight of the variance term in the loss.
-        neg_cov_weight: The weight of the negative covariance term in the loss.
-        num_heads: The number of reporter heads to fit. In other words, the number
-            of eigenvectors to compute from the VINC matrix.
-    """
+    var_weight: float = 0.0
+    """The weight of the variance term in the loss."""
 
-    var_weight: float = 0.1
     neg_cov_weight: float = 0.5
+    """The weight of the negative covariance term in the loss."""
 
     num_heads: int = 1
+    """The number of reporter heads to fit."""
+
     save_reporter_stats: bool = False
+    """Whether to save the reporter statistics to disk in EigenReporter.save(). This
+    is useful for debugging and analysis, but can take up a lot of disk space."""
 
     def __post_init__(self):
         if not (0 <= self.neg_cov_weight <= 1):
             raise ValueError("neg_cov_weight must be in [0, 1]")
         if self.num_heads <= 0:
             raise ValueError("num_heads must be positive")
+
+    @classmethod
+    def reporter_class(cls) -> type[Reporter]:
+        return EigenReporter
 
 
 class EigenReporter(Reporter):
@@ -69,9 +71,10 @@ class EigenReporter(Reporter):
 
     config: EigenReporterConfig
 
-    intercluster_cov_M2: Tensor | None  # variance
-    intracluster_cov: Tensor | None  # invariance
-    contrastive_xcov_M2: Tensor | None  # negative covariance
+    intercluster_cov_M2: Tensor  # variance
+    intracluster_cov: Tensor  # invariance
+    contrastive_xcov_M2: Tensor  # negative covariance
+
     n: Tensor
     class_means: Tensor | None
     weight: Tensor
@@ -80,20 +83,26 @@ class EigenReporter(Reporter):
         self,
         cfg: EigenReporterConfig,
         in_features: int,
-        num_classes: int | None = 2,
+        num_classes: int | None = None,
         *,
         device: str | torch.device | None = None,
         dtype: torch.dtype | None = None,
     ):
         super().__init__()
         self.config = cfg
+        self.in_features = in_features
+        self.num_classes = num_classes
 
         # Learnable Platt scaling parameters
         self.bias = nn.Parameter(torch.zeros(cfg.num_heads, device=device, dtype=dtype))
         self.scale = nn.Parameter(torch.ones(cfg.num_heads, device=device, dtype=dtype))
 
         # Running statistics
-        self.register_buffer("n", torch.zeros((), device=device, dtype=torch.long))
+        self.register_buffer(
+            "n",
+            torch.zeros((), device=device, dtype=torch.long),
+            persistent=cfg.save_reporter_stats,
+        )
         self.register_buffer(
             "class_means",
             (
@@ -101,19 +110,23 @@ class EigenReporter(Reporter):
                 if num_classes is not None
                 else None
             ),
+            persistent=cfg.save_reporter_stats,
         )
 
         self.register_buffer(
             "contrastive_xcov_M2",
             torch.zeros(in_features, in_features, device=device, dtype=dtype),
+            persistent=cfg.save_reporter_stats,
         )
         self.register_buffer(
             "intercluster_cov_M2",
             torch.zeros(in_features, in_features, device=device, dtype=dtype),
+            persistent=cfg.save_reporter_stats,
         )
         self.register_buffer(
             "intracluster_cov",
             torch.zeros(in_features, in_features, device=device, dtype=dtype),
+            persistent=cfg.save_reporter_stats,
         )
 
         # Reporter weights
@@ -129,10 +142,12 @@ class EigenReporter(Reporter):
 
     @property
     def contrastive_xcov(self) -> Tensor:
+        assert self.n > 0, "Stats not initialized; did you set save_reporter_stats?"
         return self.contrastive_xcov_M2 / self.n
 
     @property
     def intercluster_cov(self) -> Tensor:
+        assert self.n > 0, "Stats not initialized; did you set save_reporter_stats?"
         return self.intercluster_cov_M2 / self.n
 
     @property
@@ -141,41 +156,15 @@ class EigenReporter(Reporter):
 
     @property
     def invariance(self) -> Tensor:
+        assert self.n > 0, "Stats not initialized; did you set save_reporter_stats?"
         return -self.weight @ self.intracluster_cov @ self.weight.mT
 
     @property
     def consistency(self) -> Tensor:
         return -self.weight @ self.contrastive_xcov @ self.weight.mT
 
-    def clear(self) -> None:
-        """Clear the running statistics of the reporter."""
-        assert (
-            self.contrastive_xcov_M2 is not None
-            and self.intercluster_cov_M2 is not None
-            and self.intracluster_cov is not None
-        ), "Covariance matrices have been deleted"
-        self.contrastive_xcov_M2.zero_()
-        self.intracluster_cov.zero_()
-        self.intercluster_cov_M2.zero_()
-        self.n.zero_()
-
-    def delete_stats(self) -> None:
-        """Delete the running covariance matrices.
-
-        This is useful for saving memory when we're done training the reporter.
-        """
-        self.contrastive_xcov_M2 = None
-        self.intercluster_cov_M2 = None
-        self.intracluster_cov = None
-
     @torch.no_grad()
     def update(self, hiddens: Tensor) -> None:
-        assert (
-            self.contrastive_xcov_M2 is not None
-            and self.intercluster_cov_M2 is not None
-            and self.intracluster_cov is not None
-        ), "Covariance matrices have been deleted"
-
         (n, _, k, d) = hiddens.shape
 
         # Sanity checks
@@ -228,11 +217,6 @@ class EigenReporter(Reporter):
     def fit_streaming(self, truncated: bool = False) -> float:
         """Fit the probe using the current streaming statistics."""
         inv_weight = 1 - self.config.neg_cov_weight
-        assert (
-            self.contrastive_xcov_M2 is not None
-            and self.intercluster_cov_M2 is not None
-            and self.intracluster_cov is not None
-        ), "Covariance matrices have been deleted"
         A = (
             self.config.var_weight * self.intercluster_cov
             - inv_weight * self.intracluster_cov
@@ -260,61 +244,26 @@ class EigenReporter(Reporter):
         self.weight.data = Q.T
         return -float(L[-1])
 
-    def fit(
-        self,
-        hiddens: Tensor,
-        labels: Optional[Tensor] = None,
-    ) -> float:
+    def fit(self, hiddens: Tensor) -> float:
         """Fit the probe to the contrast set `hiddens`.
 
         Args:
             hiddens: The contrast set of shape [batch, variants, choices, dim].
-            labels: The ground truth labels if available.
 
         Returns:
             loss: Negative eigenvalue associated with the VINC direction.
         """
         self.update(hiddens)
-        loss = self.fit_streaming()
+        return self.fit_streaming()
 
-        if labels is not None:
-            (_, v, k, _) = hiddens.shape
-            hiddens = rearrange(hiddens, "n v k d -> (n v k) d")
-            labels = to_one_hot(repeat(labels, "n -> (n v)", v=v), k).flatten()
-
-            self.platt_scale(labels, hiddens)
-
-        return loss
-
-    def platt_scale(self, labels: Tensor, hiddens: Tensor, max_iter: int = 100):
-        """Fit the scale and bias terms to data with LBFGS.
-
-        Args:
-            labels: Binary labels of shape [batch].
-            hiddens: Hidden states of shape [batch, dim].
-            max_iter: Maximum number of iterations for LBFGS.
-        """
-        opt = optim.LBFGS(
-            [self.bias, self.scale],
-            line_search_fn="strong_wolfe",
-            max_iter=max_iter,
-            tolerance_change=torch.finfo(hiddens.dtype).eps,
-            tolerance_grad=torch.finfo(hiddens.dtype).eps,
+    def save(self, path: Path | str) -> None:
+        """Save the reporter to a file."""
+        # We basically never want to instantiate the reporter on the same device
+        # it happened to be trained on, so we save the state dict as CPU tensors.
+        # Bizarrely, this also seems to save a LOT of disk space in some cases.
+        state = {k: v.cpu() for k, v in self.state_dict().items()}
+        state.update(
+            in_features=self.in_features,
+            num_classes=self.num_classes,
         )
-
-        def closure():
-            opt.zero_grad()
-            loss = nn.functional.binary_cross_entropy_with_logits(
-                self(hiddens), labels.float()
-            )
-
-            loss.backward()
-            return float(loss)
-
-        opt.step(closure)
-
-    def save(self, path: Path | str):
-        # TODO: this method will save separate JSON and PT files
-        if not self.config.save_reporter_stats:
-            self.delete_stats()
-        super().save(path)
+        torch.save(state, path)

--- a/elk/training/reporter.py
+++ b/elk/training/reporter.py
@@ -6,13 +6,13 @@ from pathlib import Path
 from typing import Optional
 
 import torch
-import torch.nn as nn
 from simple_parsing.helpers import Serializable
-from torch import Tensor
+from simple_parsing.helpers.serialization import load
+from torch import Tensor, nn, optim
 
 
 @dataclass
-class ReporterConfig(Serializable):
+class ReporterConfig(ABC, Serializable, decode_into_subclasses=True):
     """
     Args:
         seed: The random seed to use. Defaults to 42.
@@ -20,22 +20,21 @@ class ReporterConfig(Serializable):
 
     seed: int = 42
 
+    @classmethod
+    @abstractmethod
+    def reporter_class(cls) -> type["Reporter"]:
+        """Get the reporter class associated with this config."""
+
 
 class Reporter(nn.Module, ABC):
     """An ELK reporter network."""
 
+    # Learned Platt scaling parameters
+    bias: nn.Parameter
+    scale: nn.Parameter
+
     def reset_parameters(self):
         """Reset the parameters of the probe."""
-
-    # TODO: These methods will do something fancier in the future
-    @classmethod
-    def load(cls, path: Path | str):
-        """Load a reporter from a file."""
-        return torch.load(path)
-
-    def save(self, path: Path | str):
-        # TODO: Save separate JSON and PT files for the reporter.
-        torch.save(self, path)
 
     @abstractmethod
     def fit(
@@ -44,3 +43,57 @@ class Reporter(nn.Module, ABC):
         labels: Optional[Tensor] = None,
     ) -> float:
         ...
+
+    @classmethod
+    def load(cls, path: Path | str, *, map_location: str = "cpu"):
+        """Load a reporter from a file."""
+        obj = torch.load(path, map_location=map_location)
+        if isinstance(obj, Reporter):  # Backwards compatibility
+            return obj
+
+        # Loading a state dict rather than the full object
+        elif isinstance(obj, dict):
+            cls_path = Path(path).parent / "cfg.yaml"
+            cfg = load(ReporterConfig, cls_path)
+
+            # Non-tensor values get passed to the constructor as kwargs
+            kwargs = {}
+            special_keys = {k for k, v in obj.items() if not isinstance(v, Tensor)}
+            for k in special_keys:
+                kwargs[k] = obj.pop(k)
+
+            reporter_cls = cfg.reporter_class()
+            reporter = reporter_cls(cfg, device=map_location, **kwargs)
+            reporter.load_state_dict(obj)
+            return reporter
+        else:
+            raise TypeError(
+                f"Expected a `dict` or `Reporter` object, but got {type(obj)}."
+            )
+
+    def platt_scale(self, labels: Tensor, hiddens: Tensor, max_iter: int = 100):
+        """Fit the scale and bias terms to data with LBFGS.
+
+        Args:
+            labels: Binary labels of shape [batch].
+            hiddens: Hidden states of shape [batch, dim].
+            max_iter: Maximum number of iterations for LBFGS.
+        """
+        opt = optim.LBFGS(
+            [self.bias, self.scale],
+            line_search_fn="strong_wolfe",
+            max_iter=max_iter,
+            tolerance_change=torch.finfo(hiddens.dtype).eps,
+            tolerance_grad=torch.finfo(hiddens.dtype).eps,
+        )
+
+        def closure():
+            opt.zero_grad()
+            loss = nn.functional.binary_cross_entropy_with_logits(
+                self(hiddens), labels.float()
+            )
+
+            loss.backward()
+            return float(loss)
+
+        opt.step(closure)

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -82,11 +82,12 @@ class Elicit(Run):
                 val_pair=(val_x0, val_x1),
             )
 
-            (_, v, k, _) = first_train_h.shape
-            reporter.platt_scale(
-                to_one_hot(repeat(train_gt, "n -> (n v)", v=v), k).flatten(),
-                rearrange(first_train_h, "n v k d -> (n v k) d"),
-            )
+            # TODO: Enable Platt scaling for CCS once normalization is fixed
+            # (_, v, k, _) = first_train_h.shape
+            # reporter.platt_scale(
+            #     to_one_hot(repeat(train_gt, "n -> (n v)", v=v), k).flatten(),
+            #     rearrange(first_train_h, "n v k d -> (n v k) d"),
+            # )
 
         elif isinstance(self.net, EigenReporterConfig):
             # We set num_classes to None to enable training on datasets with different

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -9,6 +9,7 @@ import pandas as pd
 import torch
 from einops import rearrange, repeat
 from simple_parsing import subgroups
+from simple_parsing.helpers.serialization import save
 
 from ..metrics import evaluate_preds, to_one_hot
 from ..run import Run
@@ -41,6 +42,10 @@ class Elicit(Run):
         lr_dir.mkdir(parents=True, exist_ok=True)
         reporter_dir.mkdir(parents=True, exist_ok=True)
 
+        # Save the reporter config separately in the reporter directory
+        # for convenient loading of reporters later.
+        save(self.net, reporter_dir / "cfg.yaml", save_dc_types=True)
+
         return reporter_dir, lr_dir
 
     def apply_to_layer(
@@ -57,7 +62,7 @@ class Elicit(Run):
         train_dict = self.prepare_data(device, layer, "train")
         val_dict = self.prepare_data(device, layer, "val")
 
-        (first_train_h, train_labels, _), *rest = train_dict.values()
+        (first_train_h, train_gt, _), *rest = train_dict.values()
         d = first_train_h.shape[-1]
         if not all(other_h.shape[-1] == d for other_h, _, _ in rest):
             raise ValueError("All datasets must have the same hidden state size")
@@ -67,7 +72,7 @@ class Elicit(Run):
             assert len(train_dict) == 1, "CCS only supports single-task training"
 
             reporter = CcsReporter(self.net, d, device=device)
-            train_loss = reporter.fit(first_train_h, train_labels)
+            train_loss = reporter.fit(first_train_h, train_gt)
 
             (val_h, val_gt, _) = next(iter(val_dict.values()))
             x0, x1 = first_train_h.unbind(2)
@@ -77,6 +82,12 @@ class Elicit(Run):
                 val_pair=(reporter.neg_norm(val_x0), reporter.pos_norm(val_x1)),
             )
 
+            (_, v, k, _) = first_train_h.shape
+            reporter.platt_scale(
+                to_one_hot(repeat(train_gt, "n -> (n v)", v=v), k).flatten(),
+                rearrange(first_train_h, "n v k d -> (n v k) d"),
+            )
+
         elif isinstance(self.net, EigenReporterConfig):
             # We set num_classes to None to enable training on datasets with different
             # numbers of classes. Under the hood, this causes the covariance statistics
@@ -84,14 +95,14 @@ class Elicit(Run):
             reporter = EigenReporter(self.net, d, num_classes=None, device=device)
 
             hidden_list, label_list = [], []
-            for ds_name, (train_h, train_labels, _) in train_dict.items():
+            for ds_name, (train_h, train_gt, _) in train_dict.items():
                 (_, v, k, _) = train_h.shape
 
                 # Datasets can have different numbers of variants and different numbers
                 # of classes, so we need to flatten them here before concatenating
                 hidden_list.append(rearrange(train_h, "n v k d -> (n v k) d"))
                 label_list.append(
-                    to_one_hot(repeat(train_labels, "n -> (n v)", v=v), k).flatten()
+                    to_one_hot(repeat(train_gt, "n -> (n v)", v=v), k).flatten()
                 )
                 reporter.update(train_h)
 

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -105,8 +105,7 @@ class Elicit(Run):
             raise ValueError(f"Unknown reporter config type: {type(self.net)}")
 
         # Save reporter checkpoint to disk
-        with open(reporter_dir / f"layer_{layer}.pt", "wb") as file:
-            torch.save(reporter, file)
+        reporter.save(reporter_dir / f"layer_{layer}.pt")
 
         # Fit supervised logistic regression model
         if self.supervised != "none":


### PR DESCRIPTION
Still unsure why reporter file stores 1 remaining covariance matrix (I deduce this based on size). The python object being saved didn't appear to have any references to any covariance matrices (not even through gradients).