### PR TITLE
Don't try loading models from the cwd ever

### DIFF
--- a/elk/extraction/dataset_name.py
+++ b/elk/extraction/dataset_name.py
@@ -5,7 +5,7 @@ from datasets import DatasetDict
 
 def extract_dataset_name_and_config(dataset_config_str: str) -> tuple[str, str]:
     """Extract the dataset name and config name from the dataset prompt."""
-    ds_name, _, config_name = dataset_config_str.partition(" ")
+    ds_name, _, config_name = dataset_config_str.partition(":")
     return ds_name, config_name
 
 

--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -35,9 +35,9 @@ from ..utils import (
     instantiate_model,
     instantiate_tokenizer,
     is_autoregressive,
+    prevent_name_conflicts,
     select_train_val_splits,
     select_usable_devices,
-    temporary_dir_move,
 )
 from .dataset_name import (
     DatasetDictWithName,
@@ -307,7 +307,7 @@ def extract(
             dataset_name=available_splits.dataset_name,
         )
 
-    with temporary_dir_move(cfg.model):
+    with prevent_name_conflicts():
         model_cfg = AutoConfig.from_pretrained(cfg.model)
 
     ds_name, config_name = extract_dataset_name_and_config(

--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -37,6 +37,7 @@ from ..utils import (
     is_autoregressive,
     select_train_val_splits,
     select_usable_devices,
+    temporary_dir_move,
 )
 from .dataset_name import (
     DatasetDictWithName,
@@ -306,7 +307,8 @@ def extract(
             dataset_name=available_splits.dataset_name,
         )
 
-    model_cfg = AutoConfig.from_pretrained(cfg.model)
+    with temporary_dir_move(cfg.model):
+        model_cfg = AutoConfig.from_pretrained(cfg.model)
 
     ds_name, config_name = extract_dataset_name_and_config(
         dataset_config_str=cfg.prompts.datasets[0]

--- a/elk/extraction/prompt_loading.py
+++ b/elk/extraction/prompt_loading.py
@@ -28,7 +28,7 @@ class PromptConfig(Serializable):
     """
     Args:
         dataset: List of space-delimited names of the HuggingFace dataset to use, e.g.
-            `"super_glue boolq"` or `"imdb"`.
+            `"super_glue:boolq"` or `"imdb"`.
         data_dir: The directory to use for caching the dataset. Defaults to
             `~/.cache/huggingface/datasets`.
         label_column: The column containing the labels. By default, we infer this from
@@ -119,7 +119,7 @@ def load_prompts(
 
     Args:
         ds_string: Space-delimited name of the HuggingFace dataset to use,
-            e.g. `"super_glue boolq"` or `"imdb"`.
+            e.g. `"super_glue:boolq"` or `"imdb"`.
         label_column: The column containing the labels. By default, we infer this from
             the datatypes of the columns in the dataset.
         num_classes: The number of classes in the dataset. If zero, we infer this from
@@ -135,7 +135,7 @@ def load_prompts(
     Returns:
         An iterable of prompt dictionaries.
     """
-    ds_name, _, config_name = ds_string.partition(" ")
+    ds_name, _, config_name = ds_string.partition(":")
     prompter = DatasetTemplates(ds_name, config_name)
 
     ds_dict = assert_type(

--- a/elk/utils/__init__.py
+++ b/elk/utils/__init__.py
@@ -6,6 +6,7 @@ from .data_utils import (
     infer_label_column,
     infer_num_classes,
     select_train_val_splits,
+    temporary_dir_move,
 )
 from .gpu_utils import select_usable_devices
 from .hf_utils import instantiate_model, instantiate_tokenizer, is_autoregressive
@@ -34,4 +35,5 @@ __all__ = [
     "select_train_val_splits",
     "select_usable_devices",
     "stochastic_round_constrained",
+    "temporary_dir_move",
 ]

--- a/elk/utils/__init__.py
+++ b/elk/utils/__init__.py
@@ -5,8 +5,8 @@ from .data_utils import (
     has_multiple_configs,
     infer_label_column,
     infer_num_classes,
+    prevent_name_conflicts,
     select_train_val_splits,
-    temporary_dir_move,
 )
 from .gpu_utils import select_usable_devices
 from .hf_utils import instantiate_model, instantiate_tokenizer, is_autoregressive
@@ -31,9 +31,9 @@ __all__ = [
     "instantiate_tokenizer",
     "int16_to_float32",
     "is_autoregressive",
+    "prevent_name_conflicts",
     "pytree_map",
     "select_train_val_splits",
     "select_usable_devices",
     "stochastic_round_constrained",
-    "temporary_dir_move",
 ]

--- a/elk/utils/data_utils.py
+++ b/elk/utils/data_utils.py
@@ -61,7 +61,14 @@ def temporary_dir_move(path: Path | str):
     with TemporaryDirectory() as tmp:
         if path.exists():
             dest = Path(tmp) / path.name
-            path.rename(dest)
+            try:
+                path.rename(dest)
+            except OSError as e:
+                print(
+                    f"You have a local directory '{dest.absolute()}' whose name "
+                    f"conflicts with {path}. We tried to move it for you, but failed "
+                    f" with error '{e}'. Please rename the directory and try again."
+                )
         else:
             dest = None
 

--- a/elk/utils/data_utils.py
+++ b/elk/utils/data_utils.py
@@ -64,11 +64,12 @@ def temporary_dir_move(path: Path | str):
             try:
                 path.rename(dest)
             except OSError as e:
-                print(
-                    f"You have a local directory '{dest.absolute()}' whose name "
+                raise RuntimeError(
+                    f"You have a local directory '{path.absolute()}' whose name "
                     f"conflicts with {path}. We tried to move it for you, but failed "
-                    f" with error '{e}'. Please rename the directory and try again."
-                )
+                    f"with error '{e}'. Please change the current working directory "
+                    f"and try again."
+                ) from e
         else:
             dest = None
 

--- a/elk/utils/data_utils.py
+++ b/elk/utils/data_utils.py
@@ -1,6 +1,9 @@
 import copy
+from contextlib import contextmanager
 from functools import cache
+from pathlib import Path
 from random import Random
+from tempfile import TemporaryDirectory
 from typing import Any, Iterable
 
 from datasets import (
@@ -45,6 +48,28 @@ def select_train_val_splits(raw_splits: Iterable[str]) -> tuple[str, str]:
     assert len(splits) >= 2, "Must have at least two of train, val, and test splits"
 
     return tuple(splits[:2])
+
+
+@contextmanager
+def temporary_dir_move(path: Path | str):
+    """Move a file or directory to a temporary directory, then move it back.
+
+    If the path does not exist, this is a no-op.
+    """
+    path = Path(path)
+
+    with TemporaryDirectory() as tmp:
+        if path.exists():
+            dest = Path(tmp) / path.name
+            path.rename(dest)
+        else:
+            dest = None
+
+        try:
+            yield dest
+        finally:
+            if dest is not None:
+                dest.rename(path)
 
 
 def infer_label_column(features: Features) -> str:

--- a/elk/utils/hf_utils.py
+++ b/elk/utils/hf_utils.py
@@ -8,7 +8,7 @@ from transformers import (
     PreTrainedTokenizerBase,
 )
 
-from .data_utils import temporary_dir_move
+from .data_utils import prevent_name_conflicts
 
 # Ordered by preference
 _DECODER_ONLY_SUFFIXES = [
@@ -21,7 +21,7 @@ _AUTOREGRESSIVE_SUFFIXES = ["ConditionalGeneration"] + _DECODER_ONLY_SUFFIXES
 
 def instantiate_model(model_str: str, **kwargs) -> PreTrainedModel:
     """Instantiate a model string with the appropriate `Auto` class."""
-    with temporary_dir_move(model_str):
+    with prevent_name_conflicts():
         model_cfg = AutoConfig.from_pretrained(model_str)
         archs = model_cfg.architectures
         if not isinstance(archs, list):
@@ -40,7 +40,7 @@ def instantiate_model(model_str: str, **kwargs) -> PreTrainedModel:
 
 def instantiate_tokenizer(model_str: str, **kwargs) -> PreTrainedTokenizerBase:
     """Instantiate a tokenizer, using the fast one iff it exists."""
-    with temporary_dir_move(model_str):
+    with prevent_name_conflicts():
         try:
             return AutoTokenizer.from_pretrained(model_str, use_fast=True, **kwargs)
         except Exception as e:

--- a/tests/super_glue_prompts.yaml
+++ b/tests/super_glue_prompts.yaml
@@ -1,7 +1,7 @@
 balance: true
 datasets:
-  - "super_glue boolq"
-  - "super_glue copa"
+  - "super_glue:boolq"
+  - "super_glue:copa"
 label_column: null
 max_examples:
 - 5

--- a/tests/test_load_prompts.py
+++ b/tests/test_load_prompts.py
@@ -14,7 +14,7 @@ def test_load_prompts():
             ds_string = cfg.datasets[0]
             prompt_ds = load_prompts(ds_string, split_type=split_type)
 
-            ds_name, _, config_name = ds_string.partition(" ")
+            ds_name, _, config_name = ds_string.partition(":")
             prompter = DatasetTemplates(ds_name, config_name or None)
 
             limit = cfg.max_examples[0 if split_type == "train" else 1]

--- a/tests/test_smoke_eval.py
+++ b/tests/test_smoke_eval.py
@@ -106,6 +106,6 @@ def test_smoke_eval_run_tiny_gpt2_eigen(tmp_path: Path):
 
 def test_smoke_multi_eval_run_tiny_gpt2_ccs(tmp_path: Path):
     elicit = setup_elicit(tmp_path)
-    transfer_datasets = ["christykoh/imdb_pt", "super_glue boolq"]
+    transfer_datasets = ["christykoh/imdb_pt", "super_glue:boolq"]
     eval_run(elicit, transfer_datasets=transfer_datasets)
     eval_assert_files_created(elicit, transfer_datasets=transfer_datasets)


### PR DESCRIPTION
This fixes a very annoying quirk of HuggingFace `from_pretrained` methods: if you try to load, say, `huggyllama/llama-7b` when there's a folder named `huggyllama/llama-7b` in the current working directory, it'll try to load from that folder instead of the HF Hub (or the relevant cache dir). We basically never want this behavior, and it becomes a problem when you happen to be `cd`ed into the `elk-reporters` directory for example.

This PR fixes this with a little hack: we just move the offending local directory to a temp dir for a short time while we call `Auto<whatever>.from_pretrained`, then move it back. AFAICT there's not a better way to do this.

Also, as a bonus, this PR makes the change that Christy and I talked about like a week ago, where datasets like "super_glue boolq" are now named like super_glue:boolq so that you don't have to wrap it in double quotes on the command line