### PR TITLE
Lots of simplification and refactoring

### DIFF
--- a/elk/evaluation/evaluate.py
+++ b/elk/evaluation/evaluate.py
@@ -21,8 +21,10 @@ class Eval(Run):
     skip_supervised: bool = False
 
     def __post_init__(self):
+        # Set our output directory before super().execute() does
         if not self.out_dir:
-            self.out_dir = self.source / "transfer" / "+".join(self.data.datasets)
+            root = elk_reporter_dir() / self.source
+            self.out_dir = root / "transfer" / "+".join(self.data.datasets)
 
     def execute(self, highlight_color: Color = "cyan"):
         return super().execute(highlight_color, split_type="val")

--- a/elk/evaluation/evaluate.py
+++ b/elk/evaluation/evaluate.py
@@ -1,33 +1,33 @@
 from collections import defaultdict
 from dataclasses import dataclass
+from pathlib import Path
 
 import pandas as pd
 import torch
 from simple_parsing.helpers import field
 
-from ..files import elk_reporter_dir, transfer_eval_directory
+from ..files import elk_reporter_dir
 from ..metrics import evaluate_preds
 from ..run import Run
 from ..training import Reporter
+from ..utils import Color
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Eval(Run):
     """Full specification of a reporter evaluation run."""
 
-    source: str = field(default="", positional=True)
+    source: Path = field(positional=True)
     skip_supervised: bool = False
 
     def __post_init__(self):
-        assert self.source, "Must specify a source experiment."
+        if not self.out_dir:
+            self.out_dir = self.source / "transfer" / "+".join(self.data.datasets)
 
-        # Set the output directory to the transfer directory if it's not specified
-        self.out_dir = (
-            transfer_eval_directory(self.source)
-            if self.out_dir is None
-            else self.out_dir
-        )
+    def execute(self, highlight_color: Color = "cyan"):
+        return super().execute(highlight_color, split_type="val")
 
+    @torch.inference_mode()
     def apply_to_layer(
         self, layer: int, devices: list[str], world_size: int
     ) -> dict[str, pd.DataFrame]:

--- a/elk/extraction/__init__.py
+++ b/elk/extraction/__init__.py
@@ -1,7 +1,7 @@
 from .balanced_sampler import BalancedSampler, FewShotSampler
 from .extraction import Extract, extract, extract_hiddens
 from .generator import _GeneratorBuilder, _GeneratorConfig
-from .prompt_loading import PromptConfig, load_prompts
+from .prompt_loading import load_prompts
 
 __all__ = [
     "BalancedSampler",
@@ -11,6 +11,5 @@ __all__ = [
     "extract",
     "_GeneratorConfig",
     "_GeneratorBuilder",
-    "PromptConfig",
     "load_prompts",
 ]

--- a/elk/extraction/balanced_sampler.py
+++ b/elk/extraction/balanced_sampler.py
@@ -16,21 +16,18 @@ from ..utils.typing import assert_type
 class BalancedSampler(TorchIterableDataset):
     """
     A sampler that approximately balances a multi-class classification dataset in a
-    streaming fashion.
-
-    Attributes:
-        data: The input dataset to balance.
-        num_classes: The total number of classes expected in the data.
-        buffer_size: The total buffer size to use for balancing the dataset. Each class
-            will have its own buffer with this size.
-    """
+    streaming fashion."""
 
     data: Iterable[dict]
+    """The input dataset to balance."""
     label_choices: InitVar[set[Hashable]]
+    """The set of all possible class labels."""
     buffer_size: int = 1000
+    """The per-class buffer size to use for balancing the dataset."""
     buffers: dict[Hashable, deque[dict]] = field(default_factory=dict, init=False)
+    """The buffers used for balancing the dataset."""
     label_col: str = "label"
-    strict: bool = True
+    """The name of the column containing the class labels."""
 
     def __post_init__(self, label_choices: set[Hashable]):
         # Initialize empty buffers
@@ -42,13 +39,9 @@ class BalancedSampler(TorchIterableDataset):
         for sample in self.data:
             label = sample[self.label_col]
             if label not in self.buffers:
-                if self.strict:
-                    raise ValueError(
-                        f"Expected label to be one of {self.buffers}, got {label}"
-                    )
-                else:
-                    # Just skip this sample
-                    continue
+                raise ValueError(
+                    f"Expected label to be one of {self.buffers}, got {label}"
+                )
 
             # Add the sample to the buffer for its class label
             self.buffers[label].append(sample)

--- a/elk/extraction/dataset_name.py
+++ b/elk/extraction/dataset_name.py
@@ -3,7 +3,7 @@ from typing import NamedTuple
 from datasets import DatasetDict
 
 
-def extract_dataset_name_and_config(dataset_config_str: str) -> tuple[str, str]:
+def parse_dataset_string(dataset_config_str: str) -> tuple[str, str]:
     """Extract the dataset name and config name from the dataset prompt."""
     ds_name, _, config_name = dataset_config_str.partition(":")
     return ds_name, config_name

--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -329,11 +329,7 @@ def hidden_features(cfg: Extract) -> tuple[DatasetInfo, Features]:
 
     ds_features = assert_type(Features, info.features)
     label_col = prompter.label_column or infer_label_column(ds_features)
-    num_classes = (
-        2
-        if cfg.binarize
-        else (len(prompter.label_choices) or infer_num_classes(ds_features[label_col]))
-    )
+    num_classes = 2 if cfg.binarize else infer_num_classes(ds_features[label_col])
 
     num_variants = cfg.num_variants
     if num_variants < 0:

--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -43,7 +43,7 @@ from ..utils import (
 )
 from .dataset_name import (
     DatasetDictWithName,
-    extract_dataset_name_and_config,
+    parse_dataset_string,
 )
 from .generator import _GeneratorBuilder
 from .prompt_loading import load_prompts
@@ -317,9 +317,7 @@ def hidden_features(cfg: Extract) -> tuple[DatasetInfo, Features]:
     with prevent_name_conflicts():
         model_cfg = AutoConfig.from_pretrained(cfg.model)
 
-    ds_name, config_name = extract_dataset_name_and_config(
-        dataset_config_str=cfg.datasets[0]
-    )
+    ds_name, config_name = parse_dataset_string(dataset_config_str=cfg.datasets[0])
     info = get_dataset_config_info(ds_name, config_name or None)
 
     if not cfg.template_path:

--- a/elk/extraction/generator.py
+++ b/elk/extraction/generator.py
@@ -58,8 +58,6 @@ class _GeneratorBuilder(GeneratorBasedBuilder):
 
     def __init__(
         self,
-        builder_name: str | None,
-        config_name: str | None,
         split_name: str,
         split_info: SplitInfo,
         **kwargs,
@@ -68,11 +66,6 @@ class _GeneratorBuilder(GeneratorBasedBuilder):
         self.split_info = split_info
 
         super().__init__(**kwargs)
-
-        # Weirdly we need to set DatasetInfo.builder_name and DatasetInfo.config_name
-        # here, not in _info, because super().__init__ modifies them
-        self.info.builder_name = builder_name
-        self.info.config_name = config_name
 
     def _info(self):
         # Use the same builder and config name as the original builder

--- a/elk/extraction/prompt_loading.py
+++ b/elk/extraction/prompt_loading.py
@@ -1,134 +1,40 @@
 from collections import Counter
-from copy import deepcopy
-from dataclasses import dataclass
-from itertools import zip_longest
 from random import Random
-from typing import Any, Iterator, Literal, Optional
+from typing import Any, Iterator, Literal
 
-from datasets import (
-    Dataset,
-    Features,
-    load_dataset,
-)
-from datasets.distributed import split_dataset_by_node
-from simple_parsing.helpers import Serializable, field
+from datasets import ClassLabel, Dataset, Value, load_dataset
 
 from ..promptsource import DatasetTemplates
 from ..utils import (
     assert_type,
     infer_label_column,
-    infer_num_classes,
-    select_train_val_splits,
+    select_split,
 )
 from .balanced_sampler import BalancedSampler, FewShotSampler
-
-
-@dataclass
-class PromptConfig(Serializable):
-    """
-    Args:
-        dataset: List of space-delimited names of the HuggingFace dataset to use, e.g.
-            `"super_glue:boolq"` or `"imdb"`.
-        data_dir: The directory to use for caching the dataset. Defaults to
-            `~/.cache/huggingface/datasets`.
-        label_column: The column containing the labels. By default, we infer this from
-            the datatypes of the columns in the dataset; if there is only one column
-            with a `ClassLabel` datatype, we use that.
-        max_examples: The maximum number of examples to use from the val dataset.
-            If a single number, use at most that many examples for each split. If a list
-            of length 2, use the first element for the train split and the second for
-            the val split. If empty, use all examples. Defaults to empty.
-        num_shots: The number of examples to use in few-shot prompts. If zero, prompts
-            are zero-shot. Defaults to 0.
-        num_variants: The number of prompt templates to apply to each predicate upon
-            call to __getitem__. Use -1 to apply all available templates. Defaults to 1.
-        seed: The seed to use for prompt randomization. Defaults to 42.
-        stream: Whether to stream the dataset from the Internet. Defaults to False.
-    """
-
-    datasets: list[str] = field(positional=True)
-    data_dirs: list[str] = field(default_factory=list)
-    label_columns: list[str] = field(default_factory=list)
-    max_examples: list[int] = field(default_factory=lambda: [1000, 1000])
-    num_classes: int = 0
-    num_shots: int = 0
-    num_variants: int = -1
-    seed: int = 42
-    stream: bool = False
-
-    def __post_init__(self):
-        if len(self.max_examples) > 2:
-            raise ValueError(
-                "max_examples should be a list of length 0, 1, or 2,"
-                f"but got {len(self.max_examples)}"
-            )
-        if not self.max_examples:
-            self.max_examples = [int(1e100)]
-
-        # Broadcast the limit to all splits
-        if len(self.max_examples) == 1:
-            self.max_examples *= 2
-
-        # Broadcast the dataset name to all data_dirs and label_columns
-        if len(self.data_dirs) == 1:
-            self.data_dirs *= len(self.datasets)
-        elif self.data_dirs and len(self.data_dirs) != len(self.datasets):
-            raise ValueError(
-                "data_dirs should be a list of length 0, 1, or len(datasets),"
-                f" but got {len(self.data_dirs)}"
-            )
-
-        if len(self.label_columns) == 1:
-            self.label_columns *= len(self.datasets)
-        elif self.label_columns and len(self.label_columns) != len(self.datasets):
-            raise ValueError(
-                "label_columns should be a list of length 0, 1, or len(datasets),"
-                f" but got {len(self.label_columns)}"
-            )
-
-    def explode(self) -> list["PromptConfig"]:
-        """Explode the config into a list of configs, one for each dataset."""
-        copies = []
-
-        for ds, data_dir, col in zip_longest(
-            self.datasets, self.data_dirs, self.label_columns
-        ):
-            copy = deepcopy(self)
-            copy.datasets = [ds]
-            copy.data_dirs = [data_dir] if data_dir else []
-            copy.label_columns = [col] if col else []
-            copies.append(copy)
-
-        return copies
 
 
 def load_prompts(
     ds_string: str,
     *,
-    label_column: Optional[str] = None,
-    num_classes: int = 0,
+    binarize: bool = False,
     num_shots: int = 0,
     num_variants: int = -1,
     seed: int = 42,
     split_type: Literal["train", "val"] = "train",
-    stream: bool = False,
+    template_path: str | None = None,
     rank: int = 0,
     world_size: int = 1,
 ) -> Iterator[dict]:
     """Load a dataset full of prompts generated from the specified dataset.
 
     Args:
-        ds_string: Space-delimited name of the HuggingFace dataset to use,
-            e.g. `"super_glue:boolq"` or `"imdb"`.
-        label_column: The column containing the labels. By default, we infer this from
-            the datatypes of the columns in the dataset.
-        num_classes: The number of classes in the dataset. If zero, we infer this from
-            the datatypes of the columns in the dataset.
+        ds_string: Name of HF dataset to use, e.g. `"super_glue:boolq"` or `"imdb"`.
+        binarize: Whether to binarize the dataset labels for multi-class datasets.
         num_shots: The number of examples to use in few-shot prompts. If zero, prompts
             are zero-shot.
         seed: The seed to use for prompt randomization.
         split_type: Whether to use the train or val split of the dataset.
-        stream: Whether to stream the dataset from the Internet. Defaults to False.
+        template_path: Path to feed into `DatasetTemplates` for loading templates.
         rank: The rank of the current process. Defaults to 0.
         world_size: The number of processes. Defaults to 1.
 
@@ -136,27 +42,20 @@ def load_prompts(
         An iterable of prompt dictionaries.
     """
     ds_name, _, config_name = ds_string.partition(":")
-    prompter = DatasetTemplates(ds_name, config_name)
 
-    ds_dict = assert_type(
-        dict, load_dataset(ds_name, config_name or None, streaming=stream)
-    )
-    train_name, val_name = select_train_val_splits(ds_dict)
-    split_name = val_name if split_type == "val" else train_name
+    ds_dict = assert_type(dict, load_dataset(ds_name, config_name or None))
+    split_name = select_split(ds_dict, split_type)
 
-    ds = ds_dict[split_name].shuffle(seed=seed)
-    train_ds = ds_dict[train_name].shuffle(seed=seed)
-    if not stream:
-        ds = assert_type(Dataset, ds)
-        if world_size > 1:
-            ds = ds.shard(world_size, rank)
+    ds = assert_type(Dataset, ds_dict[split_name].shuffle(seed=seed))
+    if world_size > 1:
+        ds = ds.shard(world_size, rank)
 
-        ds = ds.to_iterable_dataset().cast(ds.features)
+    if template_path is None:
+        prompter = DatasetTemplates(ds_name, config_name)
+    else:
+        prompter = DatasetTemplates(template_path)
 
-    elif world_size > 1:
-        # This prints to stdout which is slightly annoying
-        ds = split_dataset_by_node(dataset=ds, rank=rank, world_size=world_size)
-
+    prompter.drop_non_mc_templates()
     num_templates = len(prompter.templates)
     num_variants = (
         num_templates if num_variants == -1 else min(num_variants, num_templates)
@@ -165,13 +64,23 @@ def load_prompts(
     if rank == 0:
         print(f"Using {num_variants} variants of each prompt")
 
-    label_column = label_column or infer_label_column(ds.features)
-    num_classes = num_classes or infer_num_classes(ds.features[label_column])
-    rng = Random(seed)
+    label_column = prompter.label_column or infer_label_column(ds.features)
 
+    label_feature = ds.features[label_column]
+    if isinstance(label_feature, ClassLabel):
+        label_choices = [label_feature.str2int(label) for label in label_feature.names]
+    elif isinstance(label_feature, Value) and label_feature.dtype == "bool":
+        label_choices = [False, True]
+    else:
+        # Which classes are actually present in this split of the dataset?
+        # This is shockingly fast since it uses an optimized Apache Arrow primitive.
+        label_choices = sorted(ds.unique(label_column))
+
+    rng = Random(seed)
     if num_shots > 0:
+        train_name = select_split(ds_dict, "train")
         fewshot = FewShotSampler(
-            train_ds,  # TODO: not iterator
+            ds_dict[train_name].shuffle(seed=seed),  # TODO: not iterator
             num_shots=num_shots,
             rng=rng,
         )
@@ -179,15 +88,23 @@ def load_prompts(
     else:
         fewshot_iter = None
 
-    # Remove everything except the label column
-    extra_cols = list(assert_type(Features, ds.features))
-    extra_cols.remove(label_column)
+    if label_column in ds.features:
+        ds = BalancedSampler(
+            ds.to_iterable_dataset(),
+            set(label_choices),
+            label_col=label_column,
+        )
+    else:
+        if rank == 0:
+            print("No label column found, not balancing")
+        ds = ds.to_iterable_dataset()
 
-    for example in BalancedSampler(ds, num_classes, label_col=label_column):
+    for example in ds:
         yield _convert_to_prompts(
             example,
+            binarize=binarize,
             label_column=label_column,
-            num_classes=num_classes,
+            label_choices=label_choices,  # type: ignore[arg-type]
             num_variants=num_variants,
             prompter=prompter,
             rng=rng,
@@ -198,14 +115,14 @@ def load_prompts(
 def _convert_to_prompts(
     example: dict[str, Any],
     prompter: DatasetTemplates,
+    binarize: bool,
     label_column: str,
-    num_classes: int,
+    label_choices: list[bool | int | str],
     num_variants: int,
     rng: Random,
-    fewshot_iter: Optional[Iterator[list[dict]]] = None,
+    fewshot_iter: Iterator[list[dict]] | None = None,
 ) -> dict[str, Any]:
     """Prompt-generating function to pass to `IterableDataset.map`."""
-    labels_are_strings = isinstance(example[label_column], str)
     prompts = []
     templates = list(prompter.templates.values())
     if num_variants < len(templates):
@@ -218,21 +135,24 @@ def _convert_to_prompts(
 
     # For sanity checking that prompts are unique
     prompt_counter = Counter()
-    label_indices = set()
+    label = example[label_column]
+
+    if binarize:
+        # Replace the full list of possibilities with a randomly sampled false label
+        # and the correct label, as done in the DLK paper. Note that this does add some
+        # "supervision" by stacking the deck in favor of the correct answer.
+        label_choices = [
+            rng.choice([c for c in label_choices if c != label]),
+            label,
+        ]
+        rng.shuffle(label_choices)
 
     for template in templates:
         choices = []
-        string_choices = template.get_answer_choices_list(example)
 
-        label = example[label_column]
-        label_indices.add(string_choices.index(label) if labels_are_strings else label)
-
-        for answer_idx in range(num_classes):
+        for pseudo_label in label_choices:
             fake_example = example.copy()
-            if labels_are_strings:
-                fake_example[label_column] = string_choices[answer_idx]
-            else:
-                fake_example[label_column] = answer_idx
+            fake_example[label_column] = pseudo_label
 
             q, a = template.apply(fake_example)
             prompt_counter[(q, a)] += 1
@@ -261,14 +181,11 @@ def _convert_to_prompts(
     if dup_count > 1:
         raise ValueError(f'Prompt duplicated {dup_count} times! "{maybe_dup}"')
 
-    # Sanity check: label should be the same across all variants
-    if len(label_indices) > 1:
-        raise ValueError(
-            f"Label index should be the same all variants, but got {label_indices}"
-        )
-
+    # Our reporter training and evaluation code assumes that the labels are integers.
+    # If they're not, we need to convert them with index(). label_choices is guaranteed
+    # to be sorted (see above).
     return dict(
-        label=label_indices.pop(),
+        label=label_choices.index(label),
         prompts=prompts,
         template_names=[template.name for template in templates],
     )

--- a/elk/extraction/prompt_loading.py
+++ b/elk/extraction/prompt_loading.py
@@ -75,6 +75,8 @@ def load_prompts(
         # Which classes are actually present in this split of the dataset?
         # This is shockingly fast since it uses an optimized Apache Arrow primitive.
         label_choices = sorted(ds.unique(label_column))
+        if rank == 0:
+            print(f"Using the following pseudo-labels: {label_choices}")
 
     rng = Random(seed)
     if num_shots > 0:

--- a/elk/promptsource/templates.py
+++ b/elk/promptsource/templates.py
@@ -1,11 +1,10 @@
-import logging
 import os
 import random
 import uuid
-from collections import Counter, defaultdict
+from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
-from shutil import rmtree
-from typing import Optional
+from typing import ClassVar
 
 import yaml
 from jinja2 import BaseLoader, Environment, meta
@@ -20,7 +19,7 @@ TEMPLATES_FOLDER_PATH = Path(__file__).parent / "templates"
 env = Environment(loader=BaseLoader)  # type: ignore
 
 # Allow the python function zip()
-env.globals.update(zip=zip)
+env.globals.update(enumerate=enumerate, zip=zip)
 
 # These are users whose datasets should be included in the results returned by
 # filter_english_datasets (regardless of their metadata)
@@ -31,8 +30,16 @@ def highlight(input):
     return "<span style='color: #F08080'>" + input + "</span>"
 
 
-def choice(choices):
-    return random.choice(choices)
+def permutation(n):
+    return random.sample(range(n), n)
+
+
+def reorder(arr, permutation):
+    return [arr[i] for i in permutation]
+
+
+def to_letter(n):
+    return chr(n + ord("A"))
 
 
 def most_frequent(items):
@@ -46,8 +53,11 @@ def most_frequent(items):
 
 
 env.filters["highlight"] = highlight
-env.filters["choice"] = choice
+env.filters["choice"] = random.choice
 env.filters["most_frequent"] = most_frequent
+env.filters["permutation"] = permutation
+env.filters["reorder"] = reorder
+env.filters["to_letter"] = to_letter
 
 
 class Template(yaml.YAMLObject):
@@ -86,45 +96,13 @@ class Template(yaml.YAMLObject):
         self.metadata = metadata if metadata is not None else Template.Metadata()
         self.answer_choices = answer_choices
 
-    def get_id(self):
-        """
-        Returns the id of the template
-
-        :return: unique id for template
-        """
-        return self.id
-
-    def get_name(self):
-        """
-        Returns the name of the template
-
-        :return: unique (per dataset) name for template
-        """
-        return self.name
-
-    def get_reference(self):
-        """
-        Returns the bibliographic reference (or author) for the template
-
-        :return: reference as a string
-        """
-        return self.reference
-
-    def get_answer_choices_expr(self):
-        """
-        Returns a Jinja expression for computing the answer choices from an example.
-
-        :return: String, or None if no answer choices
-        """
-        return self.answer_choices
-
     def get_answer_choices_list(self, example):
         """
         Returns a list of answer choices for a given example
 
         :return: list of strings, or None if get_answer_choices_expr is None
         """
-        jinja = self.get_answer_choices_expr()
+        jinja = self.answer_choices
         if jinja is None:
             return None
 
@@ -141,7 +119,7 @@ class Template(yaml.YAMLObject):
         Returns a list of answer choices that is static across examples, if possible
         :return: list of strings, or None if no static list exists
         """
-        jinja = self.get_answer_choices_expr()
+        jinja = self.answer_choices
         if jinja is None:
             return None
 
@@ -176,8 +154,8 @@ class Template(yaml.YAMLObject):
         # Highlights text that was substituted for variables, if requested
         if highlight_variables:
             jinja = jinja.replace("}}", " | highlight }}")
-        rtemplate = env.from_string(jinja)
 
+        rtemplate = env.from_string(jinja)
         protected_example = self._escape_pipe(example)
 
         # Adds in answer_choices variable
@@ -242,135 +220,25 @@ class Template(yaml.YAMLObject):
         # replaces back any occurrences of the separator in a string
         return string.replace(cls.pipe_protector, "|||")
 
+    @dataclass
     class Metadata(yaml.YAMLObject):
-        """
-        Metadata for a prompt template.
-        """
+        """Metadata for a prompt template."""
 
-        yaml_tag = "!TemplateMetadata"
+        yaml_tag: ClassVar[str] = "!TemplateMetadata"
 
-        def __init__(
-            self,
-            original_task: Optional[bool] = None,
-            choices_in_prompt: Optional[bool] = None,
-            metrics: Optional[list[str]] = None,
-            languages: Optional[list[str]] = None,
-        ):
-            """
-            Initializes template metadata.
+        original_task: bool | None = None
+        """If True, this prompt asks a model to perform the original task designed for
+        this dataset."""
 
-            In the following, trivial choices are defined as Yes/No, True/False,
-            etc. and nontrivial choices are other types of choices denoted in
-            the answer_choices field.
+        choices_in_prompt: bool | None = None
+        """If True, the answer choices are included in the templates such that models
+        see those choices in the input. Only applicable to classification tasks."""
 
-            :param original_task: If True, this prompt asks a model to perform the
-                original task designed for this dataset.
-            :param choices_in_prompt: If True, the answer choices are included in the
-                templates such that models see those choices in the input. Only
-                applicable to classification tasks.
-            :param metrics: list of strings denoting metrics to use for evaluation
-            :param metrics: list of strings denoting languages used in the prompt
-                (not the associated dataset!)
-            """
-            self.original_task = original_task
-            self.choices_in_prompt = choices_in_prompt
-            self.metrics = metrics
-            self.languages = languages
+        metrics: list[str] | None = None
+        """Strings denoting metrics to use for evaluation"""
 
-
-class TemplateCollection:
-    """
-    This helper class wraps the DatasetTemplates class
-    - Initialized the DatasetTemplates for all existing template folder
-    - Give access to each DatasetTemplates
-    - Provides aggregated counts over all DatasetTemplates
-    """
-
-    def __init__(self):
-        # dict of all the DatasetTemplates, key is the tuple (dataset_name, subset_name)
-        self.datasets_templates = self._collect_datasets()
-
-    @property
-    def keys(self):
-        return list(self.datasets_templates.keys())
-
-    def __len__(self) -> int:
-        return len(self.datasets_templates)
-
-    def remove(self, dataset_name: str, subset_name: Optional[str] = None) -> None:
-        del self.datasets_templates[dataset_name, subset_name]
-
-    def _collect_datasets(self) -> dict[tuple[str, Optional[str]], "DatasetTemplates"]:
-        """
-        Initialize a DatasetTemplates object for each templates.yaml detected in the
-        templates folder
-
-        Returns: a dict with key=(dataset_name, subset_name)
-        """
-        dataset_folders = os.listdir(TEMPLATES_FOLDER_PATH)
-        dataset_folders = [
-            folder for folder in dataset_folders if not folder.startswith(".")
-        ]
-
-        output = {}  # format is {(dataset_name, subset_name): DatasetsTemplates}
-        for dataset in dataset_folders:
-            if dataset in INCLUDED_USERS:
-                for filename in os.listdir(
-                    os.path.join(TEMPLATES_FOLDER_PATH, dataset)
-                ):
-                    output = {
-                        **output,
-                        **self._collect_dataset(dataset + "/" + filename),
-                    }
-            else:
-                output = {**output, **self._collect_dataset(dataset)}
-
-        return output
-
-    def _collect_dataset(self, dataset):
-        output = {}  # format is {(dataset_name, subset_name): DatasetsTemplates}
-        for filename in os.listdir(os.path.join(TEMPLATES_FOLDER_PATH, dataset)):
-            if filename.endswith(".yaml"):
-                # If there is no sub-folder, there is no subset for this dataset
-                output[(dataset, None)] = DatasetTemplates(dataset)
-            else:
-                # This is a subfolder, and its name corresponds to the subset name
-                output[(dataset, filename)] = DatasetTemplates(
-                    dataset_name=dataset, subset_name=filename
-                )
-        return output
-
-    def get_dataset(
-        self, dataset_name: str, subset_name: Optional[str] = None
-    ) -> "DatasetTemplates":
-        """
-        Return the DatasetTemplates object corresponding to the dataset name
-
-        :param dataset_name: name of the dataset to get
-        :param subset_name: name of the subset
-        """
-        # if the dataset does not exist, we add it
-        if dataset_name not in self.keys:
-            self.datasets_templates[(dataset_name, subset_name)] = DatasetTemplates(
-                dataset_name, subset_name
-            )
-
-        return self.datasets_templates[(dataset_name, subset_name)]
-
-    def get_templates_count(self) -> dict:
-        """
-        Return the overall number count over all datasets
-
-        NB: we don't breakdown datasets into subsets for the count, i.e subsets count
-        are included into the dataset count
-        """
-
-        count_dict = defaultdict(int)
-        for k, v in self.datasets_templates.items():
-            # Subsets count towards dataset count
-            count_dict[k[0]] += len(v)
-        # converting to regular dict
-        return dict(count_dict)
+        languages: list[str] | None = None
+        """Strings denoting languages used in the prompt"""
 
 
 class DatasetTemplates:
@@ -379,28 +247,32 @@ class DatasetTemplates:
     helper functions necessary to read/write to the yaml file
     """
 
-    TEMPLATES_KEY = "templates"
-    DATASET_KEY = "dataset"
-    SUBSET_KEY = "subset"
-    TEMPLATE_FILENAME = "templates.yaml"
+    label_column: str | None
+    templates: dict[str, Template]
 
-    def __init__(self, dataset_name: str, subset_name: Optional[str] = None):
+    def __init__(self, dataset_name: str, subset_name: str | None = None):
         self.dataset_name = dataset_name
         self.subset_name = subset_name
-        # dictionary is keyed by template name.
-        self.templates: dict = self.read_from_file()
 
-        # Mapping from template name to template id
-        self.name_to_id_mapping = {}
-        self.sync_mapping()
+        with open(self.yaml_path, "r") as f:
+            yaml_dict = yaml.load(f, Loader=yaml.FullLoader)
 
-    def sync_mapping(self) -> None:
-        """
-        Re-compute the name_to_id_mapping to ensure it is in sync with self.templates
-        """
-        self.name_to_id_mapping = {
-            template.name: template.id for template in self.templates.values()
+            # Required field; contains all the templates keyed by ID
+            self.templates = yaml_dict["templates"]
+            self.label_column = yaml_dict.get("label_column")
+
+    def drop_non_mc_templates(self) -> int:
+        """Drop all templates that aren't multiple choice, return the number dropped"""
+        mc_templates = {
+            k: v for k, v in self.templates.items() if v.answer_choices is not None
         }
+        if not mc_templates:
+            raise ValueError("No multiple choice templates found")
+
+        num_dropped = len(self.templates) - len(mc_templates)
+        self.templates = mc_templates
+
+        return num_dropped
 
     @property
     def all_template_names(self) -> list[str]:
@@ -420,131 +292,8 @@ class DatasetTemplates:
 
     @property
     def yaml_path(self) -> str:
-        return os.path.join(self.folder_path, self.TEMPLATE_FILENAME)
+        path = os.path.join(self.folder_path, "templates.yaml")
+        if not os.path.exists(path):
+            raise ValueError(f"Expected prompt templates to exist at {path}")
 
-    def format_for_dump(self) -> dict:
-        """
-        Create a formatted dictionary for the class attributes
-        """
-        formatted_dict = {
-            self.DATASET_KEY: self.dataset_name,
-            self.TEMPLATES_KEY: self.templates,
-        }
-        if self.subset_name:
-            formatted_dict[self.SUBSET_KEY] = self.subset_name
-        return formatted_dict
-
-    def read_from_file(self) -> dict:
-        """
-        Reads a file containing a prompt collection.
-        """
-
-        if not os.path.exists(self.yaml_path):
-            dataset_name = (
-                f"{self.dataset_name} {self.subset_name}"
-                if self.subset_name
-                else self.dataset_name
-            )
-            logging.warning(
-                f"Tried instantiating `DatasetTemplates` for {dataset_name}, but no "
-                f"prompts found. Please ignore this warning if you are creating new "
-                f"prompts for this dataset."
-            )
-            return {}
-        yaml_dict = yaml.load(open(self.yaml_path, "r"), Loader=yaml.FullLoader)
-        return yaml_dict[self.TEMPLATES_KEY]
-
-    def write_to_file(self) -> None:
-        """
-        Writes to a file with the current prompt collection.
-        """
-        # Sync the mapping
-        self.sync_mapping()
-
-        # We only create the folder if a template is written
-        if not os.path.exists(self.folder_path):
-            os.makedirs(self.folder_path)
-        yaml.dump(self.format_for_dump(), open(self.yaml_path, "w"))
-
-    def add_template(self, template: "Template") -> None:
-        """
-        Adds a new template for the dataset
-
-        :param template: template
-        """
-        self.templates[template.get_id()] = template
-
-        self.write_to_file()
-
-    def remove_template(self, template_name: str) -> None:
-        """
-        Deletes a template
-
-        :param template_name: name of template to remove
-        """
-
-        # Even if we have an ID, we want to check for duplicate names
-        if template_name not in self.all_template_names:
-            raise ValueError(
-                f"No template with name {template_name} for dataset "
-                f"{self.dataset_name} exists."
-            )
-
-        del self.templates[self.name_to_id_mapping[template_name]]
-
-        if len(self.templates) == 0:
-            # There is no remaining template, we can remove the entire folder
-            self.delete_folder()
-        else:
-            # We just update the file
-            self.write_to_file()
-
-    def update_template(
-        self,
-        current_template_name: str,
-        new_template_name: str,
-        jinja: str,
-        reference: str,
-        metadata: Template.Metadata,
-        answer_choices: str,
-    ) -> None:
-        """
-        Updates a pre-existing template and writes changes
-
-        :param current_template_name: current name of the template stored in
-            self.templates
-        :param new_template_name: new name for the template
-        :param jinja: new jinja entry
-        :param reference: new reference entry
-        :param metadata: a Metadata object with template annotations
-        :param answer_choices: new answer_choices string
-        """
-        template_id = self.name_to_id_mapping[current_template_name]
-        self.templates[template_id].name = new_template_name
-        self.templates[template_id].jinja = jinja
-        self.templates[template_id].reference = reference
-        self.templates[template_id].metadata = metadata
-        self.templates[template_id].answer_choices = answer_choices
-
-        self.write_to_file()
-
-    def delete_folder(self) -> None:
-        """
-        Delete the folder corresponding to self.folder_path
-        """
-        self.sync_mapping()
-
-        rmtree(self.folder_path)
-
-        # If it is a subset, we have to check whether to remove the dataset folder
-        if self.subset_name:
-            # have to check for other folders
-            base_folder = os.path.join(TEMPLATES_FOLDER_PATH, self.dataset_name)
-            if len(os.listdir(base_folder)) == 0:
-                rmtree(base_folder)
-
-    def __getitem__(self, template_key: str) -> "Template":
-        return self.templates[self.name_to_id_mapping[template_key]]
-
-    def __len__(self) -> int:
-        return len(self.templates)
+        return path

--- a/elk/run.py
+++ b/elk/run.py
@@ -21,6 +21,7 @@ from .extraction import Extract, extract
 from .extraction.dataset_name import DatasetDictWithName
 from .files import elk_reporter_dir, memorably_named_dir
 from .utils import (
+    Color,
     assert_type,
     get_layers,
     int16_to_float32,
@@ -46,7 +47,11 @@ class Run(ABC, Serializable):
     out_dir: Path | None = None
     disable_cache: bool = field(default=False, to_dict=False)
 
-    def execute(self, highlight_color: str = "cyan"):
+    def execute(
+        self,
+        highlight_color: Color = "cyan",
+        split_type: Literal["train", "val", None] = None,
+    ):
         self.datasets = [
             extract(
                 cfg,
@@ -54,6 +59,7 @@ class Run(ABC, Serializable):
                 highlight_color=highlight_color,
                 num_gpus=self.num_gpus,
                 min_gpu_mem=self.min_gpu_mem,
+                split_type=split_type,
             )
             for cfg in self.data.explode()
         ]
@@ -61,7 +67,7 @@ class Run(ABC, Serializable):
         if self.out_dir is None:
             # Save in a memorably-named directory inside of
             # ELK_REPORTER_DIR/<model_name>/<dataset_name>
-            ds_name = ", ".join(self.data.prompts.datasets)
+            ds_name = ", ".join(self.data.datasets)
             root = elk_reporter_dir() / self.data.model / ds_name
 
             self.out_dir = memorably_named_dir(root)

--- a/elk/run.py
+++ b/elk/run.py
@@ -23,7 +23,7 @@ from .files import elk_reporter_dir, memorably_named_dir
 from .utils import (
     Color,
     assert_type,
-    get_layers,
+    get_layer_indices,
     int16_to_float32,
     select_train_val_splits,
     select_usable_devices,
@@ -161,7 +161,7 @@ class Run(ABC, Serializable):
         """
         self.out_dir = assert_type(Path, self.out_dir)
 
-        layers, *rest = [get_layers(ds) for _, ds in self.datasets]
+        layers, *rest = [get_layer_indices(ds) for _, ds in self.datasets]
         assert all(x == layers for x in rest), "All datasets must have the same layers"
 
         if self.concatenated_layer_offset > 0:

--- a/elk/run.py
+++ b/elk/run.py
@@ -25,7 +25,7 @@ from .utils import (
     assert_type,
     get_layer_indices,
     int16_to_float32,
-    select_train_val_splits,
+    select_split,
     select_usable_devices,
 )
 
@@ -124,8 +124,7 @@ class Run(ABC, Serializable):
         out = {}
 
         for ds_name, ds in self.datasets:
-            train_name, val_name = select_train_val_splits(ds)
-            key = train_name if split_type == "train" else val_name
+            key = select_split(ds, split_type)
 
             split = ds[key].with_format("torch", device=device, dtype=torch.int16)
             labels = assert_type(Tensor, split["label"])

--- a/elk/run.py
+++ b/elk/run.py
@@ -67,7 +67,7 @@ class Run(ABC, Serializable):
         if self.out_dir is None:
             # Save in a memorably-named directory inside of
             # ELK_REPORTER_DIR/<model_name>/<dataset_name>
-            ds_name = ", ".join(self.data.datasets)
+            ds_name = "+".join(self.data.datasets)
             root = elk_reporter_dir() / self.data.model / ds_name
 
             self.out_dir = memorably_named_dir(root)

--- a/elk/training/sweep.py
+++ b/elk/training/sweep.py
@@ -1,8 +1,7 @@
-from copy import deepcopy
-from dataclasses import InitVar, dataclass
+from dataclasses import InitVar, dataclass, replace
 
-from ..evaluation.evaluate import Eval
-from ..extraction import Extract, PromptConfig
+from ..evaluation import Eval
+from ..extraction import Extract
 from ..files import elk_reporter_dir, memorably_named_dir
 from ..utils import colorize
 from .train import Elicit
@@ -12,10 +11,12 @@ from .train import Elicit
 class Sweep:
     models: list[str]
     """List of Huggingface model strings to sweep over."""
+
     datasets: list[str]
     """List of dataset strings to sweep over. Each dataset string can contain
     multiple datasets, separated by plus signs. For example, "sst2+imdb" will
     pool SST-2 and IMDB together."""
+
     add_pooled: InitVar[bool] = False
     """Whether to add a dataset that pools all of the other datasets together."""
 
@@ -25,7 +26,7 @@ class Sweep:
     run_template: Elicit = Elicit(
         data=Extract(
             model="<placeholder>",
-            prompts=PromptConfig(datasets=["<placeholder>"]),
+            datasets=("<placeholder>",),
         )
     )
 
@@ -62,22 +63,21 @@ class Sweep:
             }
         )
 
-        for i, model_str in enumerate(self.models):
-            # Magenta color for the model name
-            print(f"\n\033[35m===== {model_str} ({i + 1} of {M}) =====\033[0m")
+        for i, model in enumerate(self.models):
+            print(colorize(f"===== {model} ({i + 1} of {M}) =====", "magenta"))
 
             for dataset_str in self.datasets:
-                out_dir = sweep_dir / model_str / dataset_str
+                out_dir = sweep_dir / model / dataset_str
 
                 # Allow for multiple datasets to be specified in a single string with
                 # plus signs. This means we can pool datasets together inside of a
                 # single sweep.
-                train_datasets = [ds.strip() for ds in dataset_str.split("+")]
+                train_datasets = tuple(ds.strip() for ds in dataset_str.split("+"))
 
-                run = deepcopy(self.run_template)
-                run.data.model = model_str
-                run.data.prompts.datasets = train_datasets
-                run.out_dir = out_dir
+                data = replace(
+                    self.run_template.data, model=model, datasets=train_datasets
+                )
+                run = replace(self.run_template, data=data, out_dir=out_dir)
                 run.execute()
 
                 if len(eval_datasets) > 1:
@@ -89,13 +89,12 @@ class Sweep:
                     if eval_dataset in train_datasets:
                         continue
 
-                    data = deepcopy(run.data)
-                    data.model = model_str
-                    data.prompts.datasets = [eval_dataset]
-
+                    assert run.out_dir is not None
                     eval = Eval(
-                        data=data,
-                        source=str(run.out_dir),
-                        out_dir=out_dir,
+                        data=replace(run.data, model=model, datasets=(eval_dataset,)),
+                        source=run.out_dir,
+                        out_dir=out_dir / "transfer" / eval_dataset,
+                        num_gpus=run.num_gpus,
+                        min_gpu_mem=run.min_gpu_mem,
                     )
                     eval.execute(highlight_color="green")

--- a/elk/utils/__init__.py
+++ b/elk/utils/__init__.py
@@ -1,24 +1,24 @@
 from .data_utils import (
-    binarize,
     get_columns_all_equal,
     get_layers,
     has_multiple_configs,
     infer_label_column,
     infer_num_classes,
     prevent_name_conflicts,
+    select_split,
     select_train_val_splits,
 )
 from .gpu_utils import select_usable_devices
 from .hf_utils import instantiate_model, instantiate_tokenizer, is_autoregressive
 from .math_util import batch_cov, cov_mean_fused, stochastic_round_constrained
-from .pretty import colorize
+from .pretty import Color, colorize
 from .tree_utils import pytree_map
 from .typing import assert_type, float32_to_int16, int16_to_float32
 
 __all__ = [
     "assert_type",
     "batch_cov",
-    "binarize",
+    "Color",
     "colorize",
     "cov_mean_fused",
     "float32_to_int16",
@@ -33,6 +33,7 @@ __all__ = [
     "is_autoregressive",
     "prevent_name_conflicts",
     "pytree_map",
+    "select_split",
     "select_train_val_splits",
     "select_usable_devices",
     "stochastic_round_constrained",

--- a/elk/utils/__init__.py
+++ b/elk/utils/__init__.py
@@ -1,6 +1,6 @@
 from .data_utils import (
     get_columns_all_equal,
-    get_layers,
+    get_layer_indices,
     has_multiple_configs,
     infer_label_column,
     infer_num_classes,
@@ -23,7 +23,7 @@ __all__ = [
     "cov_mean_fused",
     "float32_to_int16",
     "get_columns_all_equal",
-    "get_layers",
+    "get_layer_indices",
     "has_multiple_configs",
     "infer_label_column",
     "infer_num_classes",

--- a/elk/utils/data_utils.py
+++ b/elk/utils/data_utils.py
@@ -1,21 +1,17 @@
-import copy
 import os
 from contextlib import contextmanager
 from functools import cache
-from random import Random
 from tempfile import TemporaryDirectory
-from typing import Any, Iterable
+from typing import Any, Iterable, Literal
 
 from datasets import (
     ClassLabel,
     DatasetDict,
     Features,
-    Split,
     Value,
     get_dataset_config_names,
 )
 
-from ..promptsource.templates import Template
 from .typing import assert_type
 
 
@@ -29,10 +25,36 @@ def get_columns_all_equal(dataset: DatasetDict) -> list[str]:
     return pivot
 
 
+def get_split_priority(split: str) -> int:
+    """Return an integer indicating how "test-like" a split is given its name."""
+    if split.startswith("train"):
+        return 0
+    elif split.startswith("dev") or split.startswith("val"):
+        return 1
+    elif split.startswith("test"):
+        return 2
+
+    return 3
+
+
 @cache
 def has_multiple_configs(ds_name: str) -> bool:
     """Return whether a dataset has multiple configs."""
     return len(get_dataset_config_names(ds_name)) > 1
+
+
+def select_split(raw_splits: Iterable[str], split_type: Literal["train", "val"]) -> str:
+    """Return the train or validation split to use, given an Iterable of splits."""
+    assert split_type in ("train", "val"), f"Invalid split type: {split_type}"
+
+    # Note we use the alphabetical order of the splits as a tiebreaker.
+    sorted_splits = sorted(raw_splits, key=lambda k: (get_split_priority(k), k))
+    if not sorted_splits:
+        raise ValueError("No splits found!")
+    elif len(sorted_splits) == 1:
+        return sorted_splits[0]
+    else:
+        return sorted_splits[0] if split_type == "train" else sorted_splits[1]
 
 
 @contextmanager
@@ -50,13 +72,7 @@ def prevent_name_conflicts():
 def select_train_val_splits(raw_splits: Iterable[str]) -> tuple[str, str]:
     """Return splits to use for train and validation, given an Iterable of splits."""
 
-    priorities = {
-        Split.TRAIN: 0,
-        Split.VALIDATION: 1,
-        Split.TEST: 2,
-    }
-
-    splits = sorted(raw_splits, key=lambda k: priorities.get(k, 100))  # type: ignore
+    splits = sorted(raw_splits, key=lambda k: (get_split_priority(k), k))
     assert len(splits) >= 2, "Must have at least two of train, val, and test splits"
 
     return tuple(splits[:2])
@@ -113,33 +129,3 @@ def get_layers(ds: DatasetDict) -> list[int]:
         if feat.startswith("hidden_")
     ]
     return layers
-
-
-def binarize(template: Template, label: int, new_label: int, rng: Random) -> Template:
-    """Binarize a template with >2 answer choices, returning a new template and label.
-    Returns:
-        `new_template`:
-            A deepcopy of the original template with with 2 answer choices, one of
-            which is the true answer and the other is a random false answer.
-        `new_label`:
-            the index of the true answer into `new_template.answer_choices`
-    """
-
-    # TODO: it would be nice in the future to binarize exhaustively so we're not
-    # cheating here (since this step requires a label). e.g. this function would
-    # also take a candidate answer and the template would ask whether the candidate
-    # answer is true or false. This would require rewriting the jinja templates though.
-    answer_choices = assert_type(str, template.answer_choices).split(" ||| ")
-    assert len(answer_choices) > 2
-
-    true = answer_choices[label]
-    false = rng.choice([c for c in answer_choices if c != true])
-
-    assert new_label in (0, 1)
-
-    new_template = copy.deepcopy(template)
-    new_template.answer_choices = (
-        f"{false} ||| {true}" if new_label else f"{true} ||| {false}"
-    )
-
-    return new_template

--- a/elk/utils/data_utils.py
+++ b/elk/utils/data_utils.py
@@ -120,12 +120,11 @@ def infer_num_classes(label_feature: Any) -> int:
         )
 
 
-def get_layers(ds: DatasetDict) -> list[int]:
-    """Get a list of indices of hidden layers given a `DatasetDict`."""
-    train, _ = select_train_val_splits(ds.keys())
-    layers = [
-        int(feat[len("hidden_") :])
-        for feat in ds[train].features
-        if feat.startswith("hidden_")
-    ]
-    return layers
+def get_layer_indices(ds: DatasetDict) -> list[int]:
+    """Return the indices of the layers from which the hiddens have been extracted."""
+    # Dataset has a bunch of columns of the form "hidden_0", "hidden_1", etc.
+    # str.removeprefix() is a no-op if the prefix isn't present
+    suffixes = (col.removeprefix("hidden_") for col in get_columns_all_equal(ds))
+
+    # Convert to the suffixes that are integral to ints, then sort them
+    return sorted(int(suffix) for suffix in suffixes if suffix.isdigit())

--- a/elk/utils/gpu_utils.py
+++ b/elk/utils/gpu_utils.py
@@ -3,6 +3,7 @@
 import os
 import time
 import warnings
+from functools import cache
 
 import pynvml
 import torch
@@ -10,6 +11,13 @@ import torch
 from .typing import assert_type
 
 
+# We cache the results primarily so that we don't display "Using N of M GPUs..."
+# multiple times during the same run. This does sort of assume that once we identify
+# a GPU as being available, it will remain available for the duration of the run.
+# This seems to be a reasonable assumption because PyTorch tends to hold onto VRAM
+# for later use once it's been allocated. Calling torch.cuda.empty_cache() might break
+# this assumption, but we never do that.
+@cache
 def select_usable_devices(
     num_gpus: int = -1, *, min_memory: int | None = None
 ) -> list[str]:

--- a/elk/utils/pretty.py
+++ b/elk/utils/pretty.py
@@ -1,4 +1,4 @@
-# Kind of kickass that this file has no imports
+from typing import Literal
 
 # ANSI color codes for use in terminal output.
 COLOR_CODES = {
@@ -11,9 +11,10 @@ COLOR_CODES = {
     "cyan": 36,
     "white": 37,
 }
+Color = Literal["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"]
 
 
-def colorize(message: str, color: str) -> str:
+def colorize(message: str, color: Color) -> str:
     """Colorize a message for terminal output."""
     # Get the ANSI color code based on the human-readable color name.
     code = COLOR_CODES.get(color.lower())

--- a/tests/dbpedia_prompts.yaml
+++ b/tests/dbpedia_prompts.yaml
@@ -1,10 +1,10 @@
 balance: true
 datasets:
   - "dbpedia_14"
-label_column: null
 max_examples:
 - 5
 - 5
+model: gpt2
 num_shots: 0
 num_variants: -1
 seed: 42

--- a/tests/super_glue_prompts.yaml
+++ b/tests/super_glue_prompts.yaml
@@ -2,10 +2,10 @@ balance: true
 datasets:
   - "super_glue:boolq"
   - "super_glue:copa"
-label_column: null
 max_examples:
 - 5
 - 5
+model: gpt2
 num_shots: 0
 num_variants: -1
 seed: 42

--- a/tests/test_load_prompts.py
+++ b/tests/test_load_prompts.py
@@ -3,19 +3,20 @@ from typing import Literal
 
 import pytest
 
-from elk.extraction import PromptConfig, load_prompts
+from elk.extraction import Extract, load_prompts
 from elk.promptsource.templates import DatasetTemplates
 
 
 @pytest.mark.filterwarnings("ignore:Unable to find a decoding function")
 def test_load_prompts():
-    def test_single_split(cfg: PromptConfig, split_type: Literal["train", "val"]):
+    def test_single_split(cfg: Extract, split_type: Literal["train", "val"]):
         for cfg in cfg.explode():
             ds_string = cfg.datasets[0]
             prompt_ds = load_prompts(ds_string, split_type=split_type)
 
             ds_name, _, config_name = ds_string.partition(":")
             prompter = DatasetTemplates(ds_name, config_name or None)
+            prompter.drop_non_mc_templates()
 
             limit = cfg.max_examples[0 if split_type == "train" else 1]
             for record in islice(prompt_ds, limit):
@@ -29,11 +30,11 @@ def test_load_prompts():
 
     # the case where the dataset has 2 classes
     # this dataset is small
-    cfg = PromptConfig.load_yaml("tests/super_glue_prompts.yaml")
+    cfg = Extract.load_yaml("tests/super_glue_prompts.yaml")
     test_single_split(cfg, "train")
     test_single_split(cfg, "val")
 
     # the case where the dataset has more than 2 classes
-    cfg = PromptConfig.load_yaml("tests/dbpedia_prompts.yaml")
+    cfg = Extract.load_yaml("tests/dbpedia_prompts.yaml")
     test_single_split(cfg, "train")
     test_single_split(cfg, "val")

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -41,7 +41,7 @@ def test_output_is_roughly_balanced():
     )
 
     col = infer_label_column(dataset.features)
-    reservoir = BalancedSampler(dataset, 2)
+    reservoir = BalancedSampler(dataset, {0, 1})
 
     # Count the number of samples for each label
     counter = Counter()

--- a/tests/test_smoke_elicit.py
+++ b/tests/test_smoke_elicit.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 from elk import Extract
-from elk.extraction import PromptConfig
 from elk.training import CcsReporterConfig, EigenReporterConfig
 from elk.training.train import Elicit
 
@@ -13,7 +12,8 @@ def test_smoke_elicit_run_tiny_gpt2_ccs(tmp_path: Path):
     elicit = Elicit(
         data=Extract(
             model=model_path,
-            prompts=PromptConfig(datasets=[dataset_name], max_examples=[10]),
+            datasets=(dataset_name,),
+            max_examples=(10, 10),
             # run on all layers, tiny-gpt only has 2 layers
         ),
         num_gpus=2,
@@ -43,7 +43,8 @@ def test_smoke_elicit_run_tiny_gpt2_eigen(tmp_path: Path):
     elicit = Elicit(
         data=Extract(
             model=model_path,
-            prompts=PromptConfig(datasets=[dataset_name], max_examples=[10]),
+            datasets=(dataset_name,),
+            max_examples=(10, 10),
             # run on all layers, tiny-gpt only has 2 layers
         ),
         num_gpus=2,

--- a/tests/test_smoke_eval.py
+++ b/tests/test_smoke_eval.py
@@ -1,13 +1,10 @@
 from pathlib import Path
-from typing import Sequence
 
 import pandas as pd
 
 from elk import Extract
 from elk.evaluation import Eval
-from elk.extraction import PromptConfig
 from elk.extraction.dataset_name import extract_dataset_name_and_config
-from elk.files import transfer_eval_directory
 from elk.training import CcsReporterConfig, EigenReporterConfig
 from elk.training.train import Elicit
 
@@ -32,7 +29,8 @@ def setup_elicit(
     elicit = Elicit(
         data=Extract(
             model=model_path,
-            prompts=PromptConfig(datasets=[dataset_name], max_examples=[10]),
+            datasets=(dataset_name,),
+            max_examples=(10, 10),
             # run on all layers, tiny-gpt only has 2 layers
         ),
         num_gpus=2,
@@ -52,28 +50,31 @@ def check_contains_files(dir: Path, expected_files: list[str]):
         assert file in created_file_names
 
 
-def eval_run(elicit: Elicit, transfer_datasets: Sequence[str] = []) -> int:
+def eval_run(elicit: Elicit, transfer_datasets: tuple[str, ...] = ()) -> float:
     """A single eval run; act and assert that expected files were created.
     Returns a reference time (in seconds) for file modification checking.
     """
     tmp_path = elicit.out_dir
     extract = elicit.data
+    assert tmp_path is not None
 
     # record elicit modification time as reference.
     start_time_sec = (tmp_path / "eval.csv").stat().st_mtime
 
     if transfer_datasets:
         # update datasets to a different dataset
-        extract.prompts.datasets = transfer_datasets
+        extract.datasets = transfer_datasets
 
     eval = Eval(data=extract, source=tmp_path)
     eval.execute()
     return start_time_sec
 
 
-def eval_assert_files_created(elicit: Elicit, transfer_datasets: Sequence[str] = []):
+def eval_assert_files_created(elicit: Elicit, transfer_datasets: tuple[str, ...] = ()):
     tmp_path = elicit.out_dir
-    eval_dir = transfer_eval_directory(source=tmp_path)
+    assert tmp_path is not None
+
+    eval_dir = tmp_path / "transfer" / "+".join(transfer_datasets)
     assert eval_dir.exists(), f"transfer eval dir {eval_dir} does not exist"
     check_contains_files(eval_dir, EVAL_EXPECTED_FILES)
     # read "eval.csv" into a df
@@ -92,20 +93,20 @@ def eval_assert_files_created(elicit: Elicit, transfer_datasets: Sequence[str] =
 
 def test_smoke_tfr_eval_run_tiny_gpt2_ccs(tmp_path: Path):
     elicit = setup_elicit(tmp_path)
-    transfer_datasets = ["christykoh/imdb_pt"]
+    transfer_datasets = ("christykoh/imdb_pt",)
     eval_run(elicit, transfer_datasets=transfer_datasets)
     eval_assert_files_created(elicit, transfer_datasets=transfer_datasets)
 
 
 def test_smoke_eval_run_tiny_gpt2_eigen(tmp_path: Path):
     elicit = setup_elicit(tmp_path, is_ccs=False)
-    transfer_datasets = ["christykoh/imdb_pt"]
+    transfer_datasets = ("christykoh/imdb_pt",)
     eval_run(elicit, transfer_datasets=transfer_datasets)
     eval_assert_files_created(elicit, transfer_datasets=transfer_datasets)
 
 
 def test_smoke_multi_eval_run_tiny_gpt2_ccs(tmp_path: Path):
     elicit = setup_elicit(tmp_path)
-    transfer_datasets = ["christykoh/imdb_pt", "super_glue:boolq"]
+    transfer_datasets = ("christykoh/imdb_pt", "super_glue:boolq")
     eval_run(elicit, transfer_datasets=transfer_datasets)
     eval_assert_files_created(elicit, transfer_datasets=transfer_datasets)

--- a/tests/test_smoke_eval.py
+++ b/tests/test_smoke_eval.py
@@ -4,7 +4,6 @@ import pandas as pd
 
 from elk import Extract
 from elk.evaluation import Eval
-from elk.extraction.dataset_name import extract_dataset_name_and_config
 from elk.training import CcsReporterConfig, EigenReporterConfig
 from elk.training.train import Elicit
 
@@ -84,8 +83,7 @@ def eval_assert_files_created(elicit: Elicit, transfer_datasets: tuple[str, ...]
 
     for tfr_dataset in transfer_datasets:
         # assert that the dataset column contains the transfer dataset
-        ds_name, config_name = extract_dataset_name_and_config(tfr_dataset)
-        assert ds_name in dataset_col.values
+        assert tfr_dataset in dataset_col.values
 
 
 """TESTS"""


### PR DESCRIPTION
- Merge `PromptConfig` into `Extract`, cleaning up the doc strings
- Makes sure to only extract the validation split when we're doing eval
- Replaced the `label_columns` command line arg with a new entry in the prompt template .yaml which indicates what the label column should be
- Got rid of streaming dataset support because it's ~impossible to verify that the data is shuffled correctly and we never used it
- Removed unused stuff in the promptsource module
- Only print `Using X GPUs` once in the lifetime of a program
- Some other things I'm forgetting probably