### PR TITLE
Load fp32 models in bfloat16 when possible

### DIFF
--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -172,7 +172,7 @@ def extract_hiddens(
     # welcome message on every rank
     with redirect_stdout(None) if rank != 0 else nullcontext():
         model = instantiate_model(
-            cfg.model, device_map={"": device}, load_in_8bit=cfg.int8, torch_dtype=dtype
+            cfg.model, device=device, load_in_8bit=cfg.int8, torch_dtype=dtype
         )
         tokenizer = instantiate_tokenizer(
             cfg.model, truncation_side="left", verbose=rank == 0

--- a/elk/utils/__init__.py
+++ b/elk/utils/__init__.py
@@ -13,7 +13,7 @@ from .hf_utils import instantiate_model, instantiate_tokenizer, is_autoregressiv
 from .math_util import batch_cov, cov_mean_fused, stochastic_round_constrained
 from .pretty import Color, colorize
 from .tree_utils import pytree_map
-from .typing import assert_type, float32_to_int16, int16_to_float32
+from .typing import assert_type, float_to_int16, int16_to_float32
 
 __all__ = [
     "assert_type",
@@ -21,7 +21,7 @@ __all__ = [
     "Color",
     "colorize",
     "cov_mean_fused",
-    "float32_to_int16",
+    "float_to_int16",
     "get_columns_all_equal",
     "get_layer_indices",
     "has_multiple_configs",

--- a/elk/utils/hf_utils.py
+++ b/elk/utils/hf_utils.py
@@ -32,16 +32,32 @@ def instantiate_model(
     with prevent_name_conflicts():
         model_cfg = AutoConfig.from_pretrained(model_str)
 
+        # When the torch_dtype is None, this generally means the model is fp32, because
+        # the config was probably created before the `torch_dtype` field was added.
+        fp32_weights = model_cfg.torch_dtype in (None, torch.float32)
+
+        # Required by `bitsandbytes` to load in 8-bit.
+        if kwargs.get("load_in_8bit"):
+            # Sanity check: we probably shouldn't be loading in 8-bit if the checkpoint
+            # is in fp32. `bitsandbytes` only supports mixed fp16/int8 inference, and
+            # we can't guarantee that there won't be overflow if we downcast to fp16.
+            if fp32_weights:
+                raise ValueError("Cannot load in 8-bit if weights are fp32")
+
+            kwargs["torch_dtype"] = torch.float16
+
+        # CPUs generally don't support anything other than fp32.
+        elif device.type == "cpu":
+            kwargs["torch_dtype"] = torch.float32
+
         # If the model is fp32 but bf16 is available, convert to bf16.
         # Usually models with fp32 weights were actually trained in bf16, and
         # converting them doesn't hurt performance.
-        if (
-            device.type != "cpu"
-            and model_cfg.torch_dtype == torch.float32
-            and torch.cuda.is_bf16_supported()
-        ):
+        elif fp32_weights and torch.cuda.is_bf16_supported():
             kwargs["torch_dtype"] = torch.bfloat16
-            print("Weights are in fp32, but bf16 is available. Converting to bf16.")
+            print("Weights seem to be fp32, but bf16 is available. Loading in bf16.")
+        else:
+            kwargs["torch_dtype"] = "auto"
 
         archs = model_cfg.architectures
         if not isinstance(archs, list):

--- a/elk/utils/typing.py
+++ b/elk/utils/typing.py
@@ -13,8 +13,8 @@ def assert_type(typ: Type[T], obj: Any) -> T:
     return cast(typ, obj)
 
 
-def float32_to_int16(x: torch.Tensor) -> torch.Tensor:
-    """Converts float32 to float16, then reinterprets as int16."""
+def float_to_int16(x: torch.Tensor) -> torch.Tensor:
+    """Converts a floating point tensor to float16, then reinterprets as int16."""
     downcast = x.type(torch.float16)
     if not downcast.isfinite().all():
         raise ValueError("Cannot convert to 16 bit: values are not finite")


### PR DESCRIPTION
Several models that we'd like to evaluate on, like `bigscience/mt0-xxl` and `allenai/unifiedqa-t5-11b`, have float32 checkpoints but were actually trained in bfloat16 on TPUs. Because they're float32, we get out of memory errors when trying to run inference on them. This PR automatically detects if a checkpoint is (likely) float32 before downloading it, and sets `torch_dtype=torch.bfloat16` iff `torch.cuda.is_bf16_supported()` is True.

Some older models, like `gpt2`, have fp32 checkpoints and were just _trained_ in full precision. But it's nearly impossible for an overflow to occur when running these models in bfloat16, since bf16 has a dynamic range almost equal to that of fp32. There is a bit of precision loss, but empirically neural nets are highly robust to this— as long as there aren't any overflows. So this _should_ be fine. We also print a warning when the downcasting does occur. Maybe we should add a flag to turn off this automatic downcasting, but I haven't included it in this PR for simplicity.