### PR TITLE
Allow prompt templates to say if they should be binarized

### DIFF
--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -344,7 +344,11 @@ def hidden_features(cfg: Extract) -> tuple[DatasetInfo, Features]:
 
     ds_features = assert_type(Features, info.features)
     label_col = prompter.label_column or infer_label_column(ds_features)
-    num_classes = 2 if cfg.binarize else infer_num_classes(ds_features[label_col])
+    num_classes = (
+        2
+        if cfg.binarize or prompter.binarize
+        else infer_num_classes(ds_features[label_col])
+    )
 
     num_variants = cfg.num_variants
     if num_variants < 0:

--- a/elk/extraction/prompt_loading.py
+++ b/elk/extraction/prompt_loading.py
@@ -55,7 +55,10 @@ def load_prompts(
     else:
         prompter = DatasetTemplates(template_path)
 
+    # If the prompt template says to binarize, we should
+    binarize = binarize or prompter.binarize
     prompter.drop_non_mc_templates()
+
     num_templates = len(prompter.templates)
     num_variants = (
         num_templates if num_variants == -1 else min(num_variants, num_templates)

--- a/elk/promptsource/templates.py
+++ b/elk/promptsource/templates.py
@@ -247,6 +247,7 @@ class DatasetTemplates:
     helper functions necessary to read/write to the yaml file
     """
 
+    binarize: bool = False
     label_column: str | None
     templates: dict[str, Template]
 
@@ -259,6 +260,7 @@ class DatasetTemplates:
 
             # Required field; contains all the templates keyed by ID
             self.templates = yaml_dict["templates"]
+            self.binarize = yaml_dict.get("binarize", False)
             self.label_column = yaml_dict.get("label_column")
 
     def drop_non_mc_templates(self) -> int:

--- a/elk/promptsource/templates/ag_news/templates.yaml
+++ b/elk/promptsource/templates/ag_news/templates.yaml
@@ -1,4 +1,5 @@
 dataset: ag_news
+binarize: true
 templates:
   24e44a81-a18a-42dd-a71c-5b31b2d2cb39: !Template
     answer_choices: World politics ||| Sports ||| Business ||| Science and technology

--- a/elk/promptsource/templates/dbpedia_14/templates.yaml
+++ b/elk/promptsource/templates/dbpedia_14/templates.yaml
@@ -1,4 +1,5 @@
 dataset: dbpedia_14
+binarize: true
 templates:
   00fa401f-3329-48fa-be4a-1b6725292ee6: !Template
     answer_choices: Company ||| Educational Institution ||| Artist ||| Athlete |||


### PR DESCRIPTION
Adds a `binarize` field to prompt template YAML files. This is sorta needed for sweeps in which some datasets need to be binarized and others do not.