### PR TITLE
`burns` shortcut dataset in sweep

### DIFF
--- a/elk/training/sweep.py
+++ b/elk/training/sweep.py
@@ -36,6 +36,29 @@ class Sweep:
         if not self.models:
             raise ValueError("No models specified")
 
+        # Check for the magic dataset "burns" which is a shortcut for all of the
+        # datasets used in Burns et al., except Story Cloze, which is not available
+        # on the Huggingface Hub.
+        if "burns" in self.datasets:
+            self.datasets.remove("burns")
+            self.datasets.extend(
+                [
+                    "ag_news",
+                    "amazon_polarity",
+                    "dbpedia_14",
+                    "glue:qnli",
+                    "imdb",
+                    "piqa",
+                    "super_glue:boolq",
+                    "super_glue:copa",
+                    "super_glue:rte",
+                ]
+            )
+            print("Interpreting `burns` as all datasets used in Burns et al. (2022)")
+
+        # Remove duplicates just in case
+        self.datasets = sorted(set(self.datasets))
+
         # Add an additional dataset that pools all of the datasets together.
         if add_pooled:
             self.datasets.append("+".join(self.datasets))

--- a/elk/training/sweep.py
+++ b/elk/training/sweep.py
@@ -54,7 +54,10 @@ class Sweep:
                     "super_glue:rte",
                 ]
             )
-            print("Interpreting `burns` as all datasets used in Burns et al. (2022)")
+            print(
+                "Interpreting `burns` as all datasets used in Burns et al. (2022) "
+                "available on the HuggingFace Hub"
+            )
 
         # Remove duplicates just in case
         self.datasets = sorted(set(self.datasets))


### PR DESCRIPTION
Adds a magic `burns` dataset which expands to all the datasets used in Burns et al. (2022) except Story Cloze, which is not on the HF Hub and may be ~impossible to access at the moment since the form is broken.