### PR TITLE
Fixes 256 - ValueError mutable default

### DIFF
--- a/elk/training/sweep.py
+++ b/elk/training/sweep.py
@@ -51,7 +51,7 @@ class Sweep:
     name: str | None = None
 
     # A bit of a hack to add all the command line arguments from Elicit
-    run_template: Elicit = field(default_factory=Elicit.Default)
+    run_template: Elicit = field(default_factory=Elicit.default)
 
     def __post_init__(self, add_pooled: bool):
         if not self.datasets:

--- a/elk/training/sweep.py
+++ b/elk/training/sweep.py
@@ -1,4 +1,4 @@
-from dataclasses import InitVar, dataclass, replace
+from dataclasses import InitVar, dataclass, replace, field
 
 import numpy as np
 import torch

--- a/elk/training/sweep.py
+++ b/elk/training/sweep.py
@@ -6,7 +6,6 @@ from datasets import get_dataset_config_info
 from transformers import AutoConfig
 
 from ..evaluation import Eval
-from ..extraction import Extract
 from ..files import memorably_named_dir, sweeps_dir
 from ..plotting.visualize import visualize_sweep
 from ..training.eigen_reporter import EigenReporterConfig
@@ -52,12 +51,7 @@ class Sweep:
     name: str | None = None
 
     # A bit of a hack to add all the command line arguments from Elicit
-    run_template: Elicit = Elicit(
-        data=Extract(
-            model="<placeholder>",
-            datasets=("<placeholder>",),
-        )
-    )
+    run_template: Elicit = field(default_factory=Elicit.Default)    
 
     def __post_init__(self, add_pooled: bool):
         if not self.datasets:

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -36,7 +36,7 @@ class Elicit(Run):
     on the training data. "cv" means to use cross-validation."""
 
     @staticmethod
-    def Default():
+    def default():
         return Elicit(
             data=Extract(
                 model="<placeholder>",

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -13,6 +13,7 @@ from simple_parsing.helpers.serialization import save
 
 from ..metrics import evaluate_preds, to_one_hot
 from ..run import Run
+from ..extraction import Extract
 from ..training.supervised import train_supervised
 from ..utils.typing import assert_type
 from .ccs_reporter import CcsReporter, CcsReporterConfig
@@ -33,6 +34,15 @@ class Elicit(Run):
     """Whether to train a supervised classifier, and if so, whether to use
     cross-validation. Defaults to "single", which means to train a single classifier
     on the training data. "cv" means to use cross-validation."""
+
+    @staticmethod 
+    def Default():
+        return Elicit(
+            data=Extract(
+                model="<placeholder>",
+                datasets=("<placeholder>",),
+            )
+        )
 
     def create_models_dir(self, out_dir: Path):
         lr_dir = None


### PR DESCRIPTION
Fixes issue #256 (https://github.com/EleutherAI/elk/issues/256) . Error message:

> ValueError: mutable default <class 'elk.training.train.Elicit'> for field run_template is not allowed: use
default_factory