### PR TITLE
Fixed bug with encoder only models not expecting "labels" argument in forward pass 

### DIFF
--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -283,7 +283,7 @@ def extract_hiddens(
                     # Record the EXACT question we fed to the model
                     variant_questions.append(text)
 
-                inputs = dict(input_ids=ids.long())
+                inputs: dict[str, Tensor | None] = dict(input_ids=ids.long())
                 if is_enc_dec:
                     inputs["labels"] = labels
                 outputs = model(**inputs, output_hidden_states=True)

--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -283,7 +283,9 @@ def extract_hiddens(
                     # Record the EXACT question we fed to the model
                     variant_questions.append(text)
 
-                inputs = dict(input_ids=ids.long(), labels=labels)
+                inputs = dict(input_ids=ids.long())
+                if is_enc_dec:
+                    inputs["labels"] = labels
                 outputs = model(**inputs, output_hidden_states=True)
 
                 # Compute the log probability of the answer tokens if available

--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -284,7 +284,7 @@ def extract_hiddens(
                     variant_questions.append(text)
 
                 inputs: dict[str, Tensor | None] = dict(input_ids=ids.long())
-                if is_enc_dec:
+                if is_enc_dec or has_lm_preds:
                     inputs["labels"] = labels
                 outputs = model(**inputs, output_hidden_states=True)
 


### PR DESCRIPTION
After fixing, I tested with:
- microsoft/deberta-v2-xxlarge
- allenai/unifiedqa-v2-t5-11b-1363200 (whole model)
- allenai/unifiedqa-v2-t5-11b-1363200 (with `--use_encoder_states`)

All of them seemed to work as expected.