### PR TITLE
Remove check_separability

### DIFF
--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -81,14 +81,6 @@ class Elicit(Run):
             reporter = CcsReporter(self.net, d, device=device, num_variants=v)
             train_loss = reporter.fit(first_train_h)
 
-            (val_h, val_gt, _) = next(iter(val_dict.values()))
-            x0, x1 = first_train_h.unbind(2)
-            val_x0, val_x1 = val_h.unbind(2)
-            pseudo_auroc = reporter.check_separability(
-                train_pair=(x0, x1),
-                val_pair=(val_x0, val_x1),
-            )
-
             (_, v, k, _) = first_train_h.shape
             reporter.platt_scale(
                 to_one_hot(repeat(train_gt, "n -> (n v)", v=v), k).flatten(),
@@ -112,7 +104,6 @@ class Elicit(Run):
                 )
                 reporter.update(train_h)
 
-            pseudo_auroc = None
             train_loss = reporter.fit_streaming()
             reporter.platt_scale(
                 torch.cat(label_list),
@@ -150,7 +141,6 @@ class Elicit(Run):
                         **meta,
                         "ensembling": mode,
                         **evaluate_preds(val_gt, val_credences, mode).to_dict(),
-                        "pseudo_auroc": pseudo_auroc,
                         "train_loss": train_loss,
                     }
                 )


### PR DESCRIPTION
This _provably_ superfluous due to Theorem 3.1 in [the LEACE paper](https://arxiv.org/abs/2306.03819). Any normalization scheme that makes sure the means are equal will max out the pseudo-AUROC.