### PR TITLE
Fix seed not exposed

### DIFF
--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -192,6 +192,7 @@ def extract_hiddens(
         template_path=cfg.template_path,
         rank=rank,
         world_size=world_size,
+        seed=cfg.seed,
     )
 
     # Add one to the number of layers to account for the embedding layer

--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -283,7 +283,7 @@ def extract_hiddens(
                     # Record the EXACT question we fed to the model
                     variant_questions.append(text)
 
-                inputs = dict(input_ids=ids.long())
+                inputs: dict[str, Tensor | None] = dict(input_ids=ids.long())
                 if is_enc_dec:
                     inputs["labels"] = labels
                 outputs = model(**inputs, output_hidden_states=True)

--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -283,8 +283,8 @@ def extract_hiddens(
                     # Record the EXACT question we fed to the model
                     variant_questions.append(text)
 
-                inputs: dict[str, Tensor | None] = dict(input_ids=ids.long())
-                if is_enc_dec or has_lm_preds:
+                inputs = dict(input_ids=ids.long())
+                if is_enc_dec:
                     inputs["labels"] = labels
                 outputs = model(**inputs, output_hidden_states=True)
 

--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -284,7 +284,7 @@ def extract_hiddens(
                     variant_questions.append(text)
 
                 inputs: dict[str, Tensor | None] = dict(input_ids=ids.long())
-                if is_enc_dec:
+                if is_enc_dec or has_lm_preds:
                     inputs["labels"] = labels
                 outputs = model(**inputs, output_hidden_states=True)
 


### PR DESCRIPTION
Before the fix, running
```bash
elk elicit gpt2 imdb --data.seed=0 --disable_cache
```
and
```bash
elk elicit gpt2 imdb --data.seed=1 --disable_cache
```
would result in identical results. Moreover, printing the `seed` on the first line of the `load_prompts` function would print `42` in both cases which is the default value. https://github.com/EleutherAI/elk/blob/a88c01a07672321e9cc0ac8d32d702e3437deb5c/elk/extraction/prompt_loading.py#L16

After the fix, running the above commands leads to different results (because different data points are sampled from the original training sets) and the print statement now correctly outputs `0` and `1`, respectively.