### PR TITLE
remove duplicate normalization

### DIFF
--- a/elk/training/ccs_reporter.py
+++ b/elk/training/ccs_reporter.py
@@ -162,7 +162,7 @@ class CcsReporter(nn.Module, PlattMixin):
         """Return the credence assigned to the hidden state `x`."""
         assert self.norm is not None, "Must call fit() before forward()"
 
-        raw_scores = self.probe(self.norm(x)).squeeze(-1)
+        raw_scores = self.probe(x).squeeze(-1)
         return raw_scores.mul(self.scale).add(self.bias).squeeze(-1)
 
     def loss(self, logit0: Tensor, logit1: Tensor) -> Tensor:


### PR DESCRIPTION
We are already doing self.norm(x) in fit, why are we running it again in forward. I think that's a mistake (?) That's why I've removed it from forward