### PR TITLE
Fix bug with non-editable installs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include elk/promptsource/templates *
+recursive-include elk/resources *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,11 @@ reportPrivateImportUsage = false
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
+[tool.setuptools.package-data]
+elk = ["*.json.", "*.yaml"]
+
 [tool.setuptools.packages.find]
-include = ["elk*"]
+include = ["elk"]
 
 [tool.ruff]
 # Enable pycodestyle (`E`), Pyflakes (`F`), and isort (`I`) codes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ reportPrivateImportUsage = false
 testpaths = ["tests"]
 
 [tool.setuptools.package-data]
-elk = ["*.json.", "*.yaml"]
+elk = ["*.json", "*.yaml"]
 
 [tool.setuptools.packages.find]
 include = ["elk"]


### PR DESCRIPTION
Right now the prompt template YAML files and the JSONs we use to generate memorable run names don't actually get installed correctly when using a non-editable pip install. This means the PyPI package is just broken 😅

This PR fixes the issue.