### PR TITLE
Fix sweep ds config bug

### DIFF
--- a/elk/training/sweep.py
+++ b/elk/training/sweep.py
@@ -22,7 +22,8 @@ def assert_models_exist(model_names):
 
 def assert_datasets_exist(dataset_names):
     for dataset_name in dataset_names:
-        get_dataset_config_info(dataset_name)
+        ds_name, _, config_name = dataset_name.partition(":")
+        get_dataset_config_info(ds_name, config_name=config_name)
 
 
 @dataclass


### PR DESCRIPTION
Previously, running ```sweep``` with datasets with config names, such as ``super_glue:boolq``, would error as Sweep would check for datasets existing without partitioning for configs as we do for ``elicit``, which this now adds support for 

Reproducing ex ``elk sweep --models bigscience/bloomz-7b1-mt --datasets super_glue:boolq``