### PR TITLE
Fix transfer plot bug

### DIFF
--- a/elk/plotting/visualize.py
+++ b/elk/plotting/visualize.py
@@ -216,26 +216,26 @@ class ModelVisualization:
         model_name = model_path.name
         is_transfer = False
 
-        def get_train_dirs(model_path):
+        def get_eval_dirs(model_path):
             # toplevel is either repo/dataset or dataset
             for toplevel in model_path.iterdir():
                 if (toplevel / "eval.csv").exists():
                     yield toplevel
                 else:
-                    for train_dir in toplevel.iterdir():
-                        yield train_dir
+                    for eval_dir in toplevel.iterdir():
+                        yield eval_dir
 
-        for train_dir in get_train_dirs(model_path):
+        for train_dir in get_eval_dirs(model_path):
             eval_df = cls._read_eval_csv(train_dir, train_dir.name, train_dir.name)
             df = pd.concat([df, eval_df], ignore_index=True)
             transfer_dir = train_dir / "transfer"
             if transfer_dir.exists():
                 is_transfer = True
-                for eval_ds_dir in transfer_dir.iterdir():
-                    eval_df = cls._read_eval_csv(
-                        eval_ds_dir, eval_ds_dir.name, train_dir.name
+                for tfr_ds_dir in get_eval_dirs(transfer_dir):
+                    tfr_df = cls._read_eval_csv(
+                        tfr_ds_dir, tfr_ds_dir.name, train_dir.name
                     )
-                    df = pd.concat([df, eval_df], ignore_index=True)
+                    df = pd.concat([df, tfr_df], ignore_index=True)
 
         df["model_name"] = model_name
         return cls(df, model_name, is_transfer)
@@ -273,6 +273,8 @@ class ModelVisualization:
     @staticmethod
     def _read_eval_csv(path, eval_dataset, train_dataset):
         file = path / "eval.csv"
+        # if not os.path.exists(file):
+        # file = path / train_dataset / "eval.csv"
         eval_df = pd.read_csv(file)
         eval_df["eval_dataset"] = eval_dataset
         eval_df["train_dataset"] = train_dataset

--- a/elk/plotting/visualize.py
+++ b/elk/plotting/visualize.py
@@ -273,8 +273,6 @@ class ModelVisualization:
     @staticmethod
     def _read_eval_csv(path, eval_dataset, train_dataset):
         file = path / "eval.csv"
-        # if not os.path.exists(file):
-        # file = path / train_dataset / "eval.csv"
         eval_df = pd.read_csv(file)
         eval_df["eval_dataset"] = eval_dataset
         eval_df["train_dataset"] = train_dataset


### PR DESCRIPTION
Previously, elk would go through ``transfer_dir`` to find eval.csv files instead of how it responsively finds csv files like in ``train_dir``, which this fixes. This also renames the ``get_train_dirs`` to be more clear when using it in both directory situations