### PR TITLE
fix: remove first layer (embeddings) from layer_indices

### DIFF
--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -194,7 +194,8 @@ def extract_hiddens(
         seed=cfg.seed,
     )
 
-    layer_indices = cfg.layers or tuple(range(model.config.num_hidden_layers))
+    layer_indices = cfg.layers or tuple(range(model.config.num_hidden_layers)[1:])
+
 
     global_max_examples = cfg.max_examples[0 if split_type == "train" else 1]
 
@@ -366,12 +367,13 @@ def hidden_features(cfg: Extract) -> tuple[DatasetInfo, Features]:
     if num_dropped:
         print(f"Dropping {num_dropped} non-multiple choice templates")
 
+    layer_indices = cfg.layers or tuple(range(model_cfg.num_hidden_layers)[1:])
     layer_cols = {
         f"hidden_{layer}": Array3D(
             dtype="int16",
             shape=(num_variants, num_classes, model_cfg.hidden_size),
         )
-        for layer in cfg.layers or range(model_cfg.num_hidden_layers)
+        for layer in layer_indices
     }
     other_cols = {
         "variant_ids": Sequence(
@@ -458,6 +460,7 @@ def extract(
     mp.set_start_method("spawn", force=True)  # type: ignore[attr-defined]
 
     ds = dict()
+    breakpoint()
     for split, builder in builders.items():
         builder.download_and_prepare(
             download_mode=DownloadMode.FORCE_REDOWNLOAD if disable_cache else None,

--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -196,7 +196,6 @@ def extract_hiddens(
 
     layer_indices = cfg.layers or tuple(range(model.config.num_hidden_layers)[1:])
 
-
     global_max_examples = cfg.max_examples[0 if split_type == "train" else 1]
 
     # break `max_examples` among the processes roughly equally

--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -194,7 +194,7 @@ def extract_hiddens(
         seed=cfg.seed,
     )
 
-    layer_indices = cfg.layers or tuple(range(model.config.num_hidden_layers)[1:])
+    layer_indices = cfg.layers or tuple(range(1, model.config.num_hidden_layers))
 
     global_max_examples = cfg.max_examples[0 if split_type == "train" else 1]
 
@@ -366,7 +366,7 @@ def hidden_features(cfg: Extract) -> tuple[DatasetInfo, Features]:
     if num_dropped:
         print(f"Dropping {num_dropped} non-multiple choice templates")
 
-    layer_indices = cfg.layers or tuple(range(model_cfg.num_hidden_layers)[1:])
+    layer_indices = cfg.layers or tuple(range(1, model_cfg.num_hidden_layers))
     layer_cols = {
         f"hidden_{layer}": Array3D(
             dtype="int16",

--- a/elk/extraction/extraction.py
+++ b/elk/extraction/extraction.py
@@ -460,7 +460,6 @@ def extract(
     mp.set_start_method("spawn", force=True)  # type: ignore[attr-defined]
 
     ds = dict()
-    breakpoint()
     for split, builder in builders.items():
         builder.download_and_prepare(
             download_mode=DownloadMode.FORCE_REDOWNLOAD if disable_cache else None,


### PR DESCRIPTION
There was a bug where the first layer 