### PR TITLE
add platt scaling for burns + fix for leace

### DIFF
--- a/elk/training/ccs_reporter.py
+++ b/elk/training/ccs_reporter.py
@@ -170,6 +170,7 @@ class CcsReporter(nn.Module, PlattMixin):
         if self._is_training:
             return raw_scores
         else:
+            # only do platt scaling after training the reporters
             platt_scaled_scores = raw_scores.mul(self.scale).add(self.bias).squeeze(-1)
             return platt_scaled_scores
 

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -82,10 +82,8 @@ class Elicit(Run):
 
             reporter = CcsReporter(self.net, d, device=device, num_variants=v)
             train_loss = reporter.fit(first_train_h)
-
             labels = to_one_hot(train_gt, k)
-            labels = repeat(train_gt, "n -> n v k", v=v, k=k)
-            reporter.platt_scale(labels, first_train_h)
+            labels = repeat(labels, "n k -> n v k", v=v)
 
         elif isinstance(self.net, EigenFitterConfig):
             fitter = EigenFitter(

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -84,6 +84,7 @@ class Elicit(Run):
             train_loss = reporter.fit(first_train_h)
             labels = to_one_hot(train_gt, k)
             labels = repeat(labels, "n k -> n v k", v=v)
+            reporter.platt_scale(labels, first_train_h)
 
         elif isinstance(self.net, EigenFitterConfig):
             fitter = EigenFitter(

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -83,12 +83,9 @@ class Elicit(Run):
             reporter = CcsReporter(self.net, d, device=device, num_variants=v)
             train_loss = reporter.fit(first_train_h)
 
-            if not self.net.norm == "burns":
-                (_, v, k, _) = first_train_h.shape
-                reporter.platt_scale(
-                    to_one_hot(repeat(train_gt, "n -> (n v)", v=v), k).flatten(),
-                    rearrange(first_train_h, "n v k d -> (n v k) d"),
-                )
+            labels = to_one_hot(train_gt, k)
+            labels = repeat(train_gt, "n -> n v k", v=v, k=k)
+            reporter.platt_scale(labels, first_train_h)
 
         elif isinstance(self.net, EigenFitterConfig):
             fitter = EigenFitter(

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -82,8 +82,7 @@ class Elicit(Run):
 
             reporter = CcsReporter(self.net, d, device=device, num_variants=v)
             train_loss = reporter.fit(first_train_h)
-            labels = to_one_hot(train_gt, k)
-            labels = repeat(labels, "n k -> n v k", v=v)
+            labels = repeat(to_one_hot(train_gt, k), "n k -> n v k", v=v)
             reporter.platt_scale(labels, first_train_h)
 
         elif isinstance(self.net, EigenFitterConfig):


### PR DESCRIPTION
- Fixes platt scaling for Leace in CCS, where even during the training of the reporters the platt scaling parameters are multiplied and added to the raw_scores.

- Adds platt_scaling when using burns normalization 